### PR TITLE
Some fixes

### DIFF
--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -416,8 +416,7 @@ class MainController(NSObject):
         if pre_first_boot:
             # have packages to install
             self.downloadAndInstallPackages_(sender)
-
-        if self.packages_to_install:
+        elif self.packages_to_install:
             # got packages to install at first boot, let's process those
             self.downloadAndCopyPackages_(sender)
         else:
@@ -442,14 +441,18 @@ class MainController(NSObject):
         # mount the target
         if not self.workVolume.Mounted():
             self.workVolume.Mount()
-
+                
+        first_boot_pkgs_to_install = False
         for item in self.selectedWorkflow['components']:
             if item['type'] == 'package':
                 if 'pre_first_boot' in item:
                     Utils.downloadAndInstallPackage(item['url'], self.workVolume.mountpoint)
+                else:
+                    first_boot_pkgs_to_install = True
+                
         # restart
         del pool
-        if self.packages_to_install:
+        if first_boot_pkgs_to_install:
             self.downloadAndCopyPackages_(sender)
         else:
             self.restartToImagedVolume_(sender)
@@ -479,7 +482,7 @@ class MainController(NSObject):
         counter = 0
         # download packages to /usr/local/first-boot - append number
         for item in self.selectedWorkflow['components']:
-            if item['type'] == 'package':
+            if item['type'] == 'package' and not 'pre_first_boot' in item:
                 counter = counter + 1
                 Utils.downloadPackage(item['url'], self.workVolume.mountpoint, counter, package_count)
         # copy bits for first boot script

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -95,7 +95,7 @@ def installPkg(pkg, target):
     installer_pool = NSAutoreleasePool.alloc().init()
     cmd = ['/usr/sbin/installer', '-pkg', pkg, '-target', target]
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    (ouput, unusederr) = proc.communicate()
+    (output, unusederr) = proc.communicate()
     if unusederr:
         NSLog(str(unusederr))
     del installer_pool
@@ -149,7 +149,7 @@ def downloadPackage(url, target, number, package_count):
         os.makedirs(os.path.join(target, "usr/local/first-boot/packages"))
     file = os.path.join(target, 'usr/local/first-boot/packages',package_name)
     output = downloadChunks(url, file)
-    return ouput
+    return output
 
 def downloadChunks(url, file):
     try:
@@ -208,7 +208,8 @@ def copyFirstBoot(root):
     os.chown(os.path.join(launchAgent_dir, 'se.gu.it.LoginLog.plist'), 0, 0)
 
     helperTools_dir = os.path.join(root, 'Library', 'PrivilegedHelperTools')
-    os.makedirs(helperTools_dir)
+    if not os.path.exists(helperTools_dir):
+        os.makedirs(helperTools_dir)
     shutil.copytree(os.path.join(script_dir, 'LoginLog.app'),
     os.path.join(helperTools_dir, 'LoginLog.app'))
     # Set the permisisons


### PR DESCRIPTION
See the commits for details, but a summary:

```
MainController.py:
    moved all global to object instance variables.
    Don't try to create usr/local/first-boot/ on the target if it already exists
    When installing packages pre-first-boot, don't also install them at first boot! One or the other only...

Utils.py:
    Fix some typos ("ouput" instead of "output")
    Don't try to create Library/PrivilegedHelperTools on the target if it already exists
```

I've tested two workflows successfully: one consisting entirely of first-boot pkg installs (no image), and one consisting solely of pre-first-boot installs (again no image); both behave as expected.
