### PR TITLE
Get proper count of each type of package to be installed (first-boot; pr...

### DIFF
--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -58,7 +58,7 @@ def getServerURL():
         pass
 
 
-def downloadAndInstallPackage(url, target):
+def downloadAndInstallPackage(url, target, number, package_count):
     if os.path.basename(url).endswith('.dmg'):
         # We're going to mount the dmg
         dmgmountpoints = mountdmg(url)


### PR DESCRIPTION
...e-first-boot). Get ready for progress feedback when installing and copying pkgs.

Since I assume the progress bar will eventually move to show progress as pkgs are installed, it seemed a good idea to fix the code that counted the number of pkgs, since we have two different workflow steps that install pkgs. counter and package_count new also passed to Utils.downloadAndInstallPackage() for future use.
