### PR TITLE
Better naming of up to 999 packages to ensure correct deployment order. ...

### DIFF
--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -147,13 +147,11 @@ def unmountdmg(mountpoint):
 
 def downloadPackage(url, target, number, package_count):
     NSLog("Downloading pkg %@", url)
-    package_name = str(number) +"-" +os.path.basename(url)
+    package_name = "%03d-%s" % (number, os.path.basename(url))
     os.umask(0002)
-    #package_name = str(number) + '-' +package_name
-    package_name = package_name.zfill(package_count)
     if not os.path.exists(os.path.join(target, "usr/local/first-boot/packages")):
         os.makedirs(os.path.join(target, "usr/local/first-boot/packages"))
-    file = os.path.join(target, 'usr/local/first-boot/packages',package_name)
+    file = os.path.join(target, 'usr/local/first-boot/packages', package_name)
     output = downloadChunks(url, file)
     return output
 


### PR DESCRIPTION
...(If we have more than that, shame on the admin!)

.zfill wasn't doing the right thing here. With this change, packages should end up named:

001-foo.pkg
002-bar.pkg
003-baz.pkg

Which should correctly handle the first 999 packages! We could be even more clever, but this should be OK.
