### PR TITLE
Simple build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
-
-Imagr.xcodeproj/xcuserdata/grahamgilbert.xcuserdatad/xcschemes/Imagr.xcscheme
+Imagr.xcodeproj/xcuserdata/*
+*.dmg
+*.pkg

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Simple build script for creating the current version of imagr for distribution.
+
+source_path=$(dirname "${0}")
+cd $source_path
+
+# Build imagr using default "release" build
+xcodebuild
+
+# Create an initial disk image (32 megs)
+hdiutil create -size 32m -fs HFS+ -volname "imagr" imagr.dmg
+
+# Mount the disk image
+hdiutil attach imagr.dmg
+
+# Copy imagr.app to dmg
+cp -r ./build/Release/Imagr.app /Volumes/imagr
+
+# Unmount the disk image
+hdiutil detach /Volumes/imagr
+
+# Convert the disk image to read-only and add version number
+version=`defaults read $(pwd)/build/Release/Imagr.app/Contents/Info.plist CFBundleShortVersionString`
+hdiutil convert imagr.dmg -format UDZO -o imagr-compressed.dmg
+mv imagr-compressed.dmg imagr-$version.dmg
+
+# Remove temp dmg
+rm imagr.dmg


### PR DESCRIPTION
This pull request adds a simple command line build script for creating the current version of imagr for distribution.

Feel free to close this pull request if you don't like this method. I found it useful for testing.
