### PR TITLE
Replace /sbin/reboot with /sbin/shutdown for the shutdown command.

### DIFF
--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -493,7 +493,7 @@ class MainController(NSObject):
         if self.restartAction == 'restart':
             cmd = ['/sbin/reboot']
         elif self.restartAction == 'shutdown':
-            cmd = ['/sbin/reboot', '-h', 'now']
+            cmd = ['/sbin/shutdown', '-h', 'now']
         task = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         task.communicate()
 


### PR DESCRIPTION
fixes #29 shutdown works as intended. 
I tested both the Shutdown and Reboot buttons at the end of a workflow.
