### PR TITLE
Proper argument quoting.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ run: build
 	sudo build/Release/Imagr.app/Contents/MacOS/Imagr
 
 config:
-	defaults write $(shell pwd)/com.grahamgilbert.Imagr serverurl $(URL)
+	defaults write "$(shell pwd)/com.grahamgilbert.Imagr" serverurl "$(URL)"
 
 deps: autonbi foundation
 
@@ -47,7 +47,7 @@ dmg: build
 	cp -r ./build/Release/Imagr.app /Volumes/Imagr
 	hdiutil detach /Volumes/Imagr
 	hdiutil convert Imagr.dmg -format UDZO -o Imagr-compressed.dmg
-	mv Imagr-compressed.dmg Imagr-$(shell /usr/bin/defaults read `pwd`/build/Release/Imagr.app/Contents/Info.plist CFBundleShortVersionString).dmg
+	mv Imagr-compressed.dmg "Imagr-$(shell /usr/bin/defaults read $$(pwd)/build/Release/Imagr.app/Contents/Info.plist" CFBundleShortVersionString).dmg
 	rm Imagr.dmg
 
 foundation:
@@ -63,7 +63,7 @@ nbi: clean-pkgs build autonbi foundation config
 	cp -r ./build/Release/Imagr.app ./Packages
 	sudo chown -R root:wheel Packages/*
 	sudo chmod -R 755 Packages/*
-	sudo ./AutoNBI.py -e -p -s $(APP) -f Packages -d $(OUTPUT) -n $(NBI)
+	sudo ./AutoNBI.py -e -p -s "$(APP)" -f Packages -d "$(OUTPUT)" -n "$(NBI)"
 	if [ -f ./FoundationPlist.py ]; then \
 		sudo rm FoundationPlist.py; \
 	fi

--- a/Readme.md
+++ b/Readme.md
@@ -193,7 +193,7 @@ The included ``Makefile`` makes the process of creating a NetInstall near painle
 ```
 # Defaults
 URL="http://192.168.178.135/imagr_config.plist"
-APP=/Applications/Install\ OS\ X\ Yosemite.app
+APP="/Applications/Install OS X Yosemite.app"
 OUTPUT=~/Desktop
 NBI="Imagr"
 ```
@@ -207,7 +207,7 @@ You can change these default variables in the ``Makefile`` or via command line a
 $ make nbi
 $ make nbi URL="http://my_server/imagr_config.plist"
 $ make nbi URL="http://my_server/imagr_config.plist" OUTPUT=~/Documents
-$ make nbi URL="http://my_server/imagr_config.plist" APP="/Applications/Install\ OS\ X\ Mavericks.app" OUTPUT=/Volumes/data/temp/ NBI="myImagr"
+$ make nbi URL="http://my_server/imagr_config.plist" APP="/Applications/Install OS X Mavericks.app" OUTPUT=/Volumes/data/temp/ NBI="myImagr"
 ```
 
 ### Manual Build Creation


### PR DESCRIPTION
No need for double quoting on the command line.
