### PR TITLE
Move AutoNBI arguments to a variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ URL="http://192.168.178.135/imagr_config.plist"
 APP="/Applications/Install OS X Yosemite.app"
 OUTPUT=~/Desktop
 NBI="Imagr"
+ARGS="-e -p"
 
 -include config.mk
 
@@ -61,7 +62,7 @@ nbi: clean-pkgs build autonbi foundation config
 	cp -r ./build/Release/Imagr.app ./Packages
 	sudo chown -R root:wheel Packages/*
 	sudo chmod -R 755 Packages/*
-	sudo ./AutoNBI.py -e -p -s $(APP) -f Packages -d $(OUTPUT) -n $(NBI)
+	sudo ./AutoNBI.py $(ARGS) -s $(APP) -f Packages -d $(OUTPUT) -n $(NBI)
 	if [ -f ./FoundationPlist.py ]; then \
 		sudo rm FoundationPlist.py; \
 	fi


### PR DESCRIPTION
As new options/features are added to AutoNBI we shouldn't need to modify Imagr to support these features. 
