### PR TITLE
Remote syslog

### DIFF
--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -214,6 +214,7 @@ class MainController(NSObject):
                 self.errorMessage = "Couldn't get configuration plist from server."
         else:
             self.errorMessage = "Configuration URL wasn't set."
+        Utils.setup_logging()
         Utils.sendReport('in_progress', 'Imagr is starting up...')
         self.performSelectorOnMainThread_withObject_waitUntilDone_(
             self.loadDataComplete, None, YES)

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -25,6 +25,7 @@ import sys
 import xml.sax.saxutils
 import logging
 import urlparse
+import socket
 
 from gurl import Gurl
 
@@ -322,15 +323,15 @@ def getReportURL():
 def sendReport(status, message):
     hardware_info = get_hardware_info()
     SERIAL = hardware_info.get('serial_number', 'UNKNOWN')
-    # Should probably do some validation on the status at some point
-    data = {
-        'status': status,
-        'serial': SERIAL,
-        'message': message
-    }
     
     report_url = getReportURL()
     if report_url:
+        # Should probably do some validation on the status at some point
+        data = {
+            'status': status,
+            'serial': SERIAL,
+            'message': message
+        }
         NSLog('Report: %@', data )
         data = urllib.urlencode(data)
         # silently fail here, sending reports is a nice to have, if server is down, meh.
@@ -339,7 +340,7 @@ def sendReport(status, message):
         except:
             pass
 
-    log_message = "[{}] {}".format(data['serial'], data['message'])
+    log_message = "[{}] {}".format(SERIAL, message)
     log = logging.getLogger("Imagr")
 
     if status == 'error':
@@ -396,42 +397,18 @@ def setup_logging():
         return
     
     # Parse syslog URI
-    hostname = 'localhost'
-    port = 514
-    transport = 'UDP'
-    facility = 'local7'
-
     try:
         uri = urlparse.urlparse(syslog)
         qs = urlparse.parse_qs(uri.query)
 
-        if uri.hostname:
-            hostname = uri.hostname
-
-        if uri.port:
-            port = uri.port
-
-        if 'transport' in qs:
-            transport = qs['transport'][0]
-
-        if 'facility' in qs:
-            facility = qs['facility'][0]
+        hostname = uri.hostname if uri.hostname else "localhost"
+        port = uri.port if uri.port else 514
+        socktype = socket.SOCK_STREAM if qs['transport'][0] == 'TCP' else socket.SOCK_DGRAM
+        facility = qs['facility'][0] if 'facility' in qs else "local7"
     except:
         NSLog("Failed to parse syslog URI.")
-        
-        pass
 
-    # Create syslog handler
-    import socket
-    
-    if transport == 'TCP':
-        socktype = socket.SOCK_STREAM
-    else:
-        if transport != 'UDP':
-            NSLog("Don't know how to handle %@, defaulting to UDP.", transport)
-        
-        socktype = socket.SOCK_DGRAM
-    
+    # Create a syslog handler
     handler = logging.handlers.SysLogHandler(address=(hostname, port),
                                              facility=facility,
                                              socktype=socktype)

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ AUTONBIURL=https://bitbucket.org/bruienne/autonbi/raw/master/AutoNBI.py
 FOUNDATIONPLISTURL=https://raw.githubusercontent.com/munki/munki/master/code/client/munkilib/FoundationPlist.py
 INDEX="5001"
 VALIDATE=True
+SYSLOG=none
 
 -include config.mk
 
@@ -51,6 +52,9 @@ endif
 	/usr/libexec/PlistBuddy -c 'Add :serverurl string "$(URL)"' com.grahamgilbert.Imagr.plist
 ifneq ($(REPORTURL),none)
 	/usr/libexec/PlistBuddy -c 'Add :reporturl string "$(REPORTURL)"' com.grahamgilbert.Imagr.plist
+endif
+ifneq ($(SYSLOG),none)
+	/usr/libexec/PlistBuddy -c 'Add :syslog string "$(SYSLOG)"' com.grahamgilbert.Imagr.plist
 endif
 
 deps: autonbi foundation


### PR DESCRIPTION
When given a syslog URI in the following form, Imagr sends reports to a remote syslog server.

```
syslog://<hostname:localhost>:<port:514>/?transport=<transport:UDP>&facility=<facility:local7>
```

The result on the remote syslog server is similar to the following.

```
 Sep  8 09:38:36 <hostname> Imagr: [<serial>] Imagr is starting up...
 Sep  8 09:38:47 <hostname> Imagr: [<serial>] Preparing to run workflow <workflow>...
 Sep  8 09:38:48 <hostname> Imagr: [<serial>] Restoring DMG: http://<hostname>/osx_custom_150814-10.10.5-14F27.hfs.dmg
 Sep  8 09:40:24 <hostname> Imagr: [<serial>] Setting computer name to <serial>
 Sep  8 09:40:29 <hostname> Imagr: [<serial>] Downloading and installing package(s): ...
 Sep  8 09:40:46 <hostname> Imagr: [<serial>] Copying first boot script 6.0
 Sep  8 09:40:47 <hostname> Imagr: [<serial>] Finished running <workflow>.
```

This fixes #98.
