### PR TITLE
Update Makefile to El Cap by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 URL="http://192.168.178.135/imagr_config.plist"
 REPORTURL=none
-APP="/Applications/Install OS X Yosemite.app"
+APP="/Applications/Install OS X El Capitan.app"
 OUTPUT=~/Desktop
 NBI="Imagr"
 ARGS= --enable-nbi --add-python


### PR DESCRIPTION
Until we kick Make we should bump this to El Captain as most people will start using this by default.
