### PR TITLE
Add default_workflow key to configuration

### DIFF
--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -84,6 +84,7 @@ class MainController(NSObject):
     targetVolume = None
     #workVolume = None
     selectedWorkflow = None
+    defaultWorkflow = None
     parentWorkflow = None
     packages_to_install = None
     restartAction = None
@@ -214,6 +215,10 @@ class MainController(NSObject):
                     self.workflows = converted_plist['workflows']
                 except:
                     self.errorMessage = "No workflows found in the configuration plist."
+                try:
+                    self.defaultWorkflow = converted_plist['default_workflow']
+                except:
+                    pass
             else:
                 self.errorMessage = "Couldn't get configuration plist from server."
         else:
@@ -391,6 +396,11 @@ class MainController(NSObject):
                 list.append(workflow['name'])
 
         self.chooseWorkflowDropDown.addItemsWithTitles_(list)
+        
+        # The current selection is deselected if a nil or non-existent title is given
+        if self.defaultWorkflow:
+            self.chooseWorkflowDropDown.selectItemWithTitle_(self.defaultWorkflow)
+        
         self.chooseWorkflowDropDownDidChange_(sender)
 
     @objc.IBAction

--- a/validateplist
+++ b/validateplist
@@ -20,6 +20,7 @@ This script will validate an Imagr configuration plist. Usage:
     #13 - Partition actions must have one 'size' for each partition, if 'size' is specified
     #14 - Partition actions must not be done at first boot
     #15 - eraseVolume actions must not be done at first boot
+    #16 - if a default workflow is specified, it must match the name of an existing workflow
 """
 
 import os
@@ -178,6 +179,11 @@ def main():
 
         for component in workflow['components']:
             validateComponent(component, workflow)
+
+    # Rule 16
+    if 'default_workflow' in config and config['default_workflow'] not in existing_names:
+        fail('Default workflow must match the name of an existing workflow.')
+
     # if we get this far, it looks good.
     print "SUCCESS: %s looks like a valid Imagr configuration plist." % plist
 if __name__ == '__main__':


### PR DESCRIPTION
The PR adds a default_workflow key to the workflow configuration.

Sample configuration:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
  <key>default_workflow</key>
  <string>Munki_10103</string>
  <key>workflows</key>
    <dict>
      <key>name</key>
      <string>Munki_10103</string>
...
```

Rule 16 was added to `validateplist` to ensure that, if this key is given, it references an existing workflow by name.  Using a non-existent workflow name wouldn't crash Imagr, it would simply [deselect the first item](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSPopUpButton_Class/index.html#//apple_ref/occ/instm/NSPopUpButton/selectItemWithTitle:) in the dropdown.
