### PR TITLE
Autorun (#112)

### DIFF
--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -269,20 +269,20 @@ class MainController(NSObject):
                 self.enableWorkflowViewControls()
                 self.theTabView.selectTabViewItem_(self.mainTab)
                 self.chooseImagingTarget_(None)
-                
-                
-                
-                # If the default workflow has "autorun" set to True, we run the default workflow without prompting.
-                for workflow in self.workflows:
-                    if not self.cancelledAutorun and self.defaultWorkflow and workflow['name'] == self.defaultWorkflow and 'autorun' in workflow and workflow['autorun']:
-                        self.autorunDefaultWorkflow = True
             
-                if self.autorunDefaultWorkflow:
-                    self.countdownOnThreadPrep()
-                #self.enableAllButtons_(self)
+                self.isAutorun()
             else:
                 self.theTabView.selectTabViewItem_(self.loginTab)
                 self.mainWindow.makeFirstResponder_(self.password)
+
+    def isAutorun(self):
+        # If the default workflow has "autorun" set to True, we run the default workflow without prompting.
+        for workflow in self.workflows:
+            if not self.cancelledAutorun and self.defaultWorkflow and workflow['name'] == self.defaultWorkflow and 'autorun' in workflow and workflow['autorun']:
+                self.autorunDefaultWorkflow = True
+                
+        if self.autorunDefaultWorkflow:
+            self.countdownOnThreadPrep()
 
     @objc.IBAction
     def reloadWorkflows_(self, sender):
@@ -308,6 +308,8 @@ class MainController(NSObject):
                 self.chooseImagingTarget_(None)
                 self.enableAllButtons_(self)
                 self.hasLoggedIn = True
+
+                self.isAutorun()
 
     @objc.IBAction
     def setStartupDisk_(self, sender):

--- a/Imagr/en.lproj/MainMenu.xib
+++ b/Imagr/en.lproj/MainMenu.xib
@@ -1,3369 +1,561 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1060</int>
-		<string key="IBDocument.SystemVersion">13F1077</string>
-		<string key="IBDocument.InterfaceBuilderVersion">6751</string>
-		<string key="IBDocument.AppKitVersion">1265.21</string>
-		<string key="IBDocument.HIToolboxVersion">698.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">6751</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>NSButton</string>
-			<string>NSButtonCell</string>
-			<string>NSCustomObject</string>
-			<string>NSImageCell</string>
-			<string>NSImageView</string>
-			<string>NSMenu</string>
-			<string>NSMenuItem</string>
-			<string>NSPopUpButton</string>
-			<string>NSPopUpButtonCell</string>
-			<string>NSProgressIndicator</string>
-			<string>NSScrollView</string>
-			<string>NSScroller</string>
-			<string>NSSecureTextField</string>
-			<string>NSSecureTextFieldCell</string>
-			<string>NSTabView</string>
-			<string>NSTabViewItem</string>
-			<string>NSTextField</string>
-			<string>NSTextFieldCell</string>
-			<string>NSTextView</string>
-			<string>NSView</string>
-			<string>NSWindowTemplate</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-		</array>
-		<dictionary class="NSMutableDictionary" key="IBDocument.Metadata"/>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1048">
-			<object class="NSCustomObject" id="1021">
-				<string key="NSClassName">NSApplication</string>
-			</object>
-			<object class="NSCustomObject" id="1014">
-				<string key="NSClassName">FirstResponder</string>
-			</object>
-			<object class="NSCustomObject" id="1050">
-				<string key="NSClassName">NSApplication</string>
-			</object>
-			<object class="NSMenu" id="649796088">
-				<string key="NSTitle">AMainMenu</string>
-				<array class="NSMutableArray" key="NSMenuItems">
-					<object class="NSMenuItem" id="694149608">
-						<reference key="NSMenu" ref="649796088"/>
-						<string key="NSTitle">Imagr</string>
-						<string key="NSKeyEquiv"/>
-						<int key="NSKeyEquivModMask">1048576</int>
-						<int key="NSMnemonicLoc">2147483647</int>
-						<object class="NSCustomResource" key="NSOnImage" id="715147791">
-							<string key="NSClassName">NSImage</string>
-							<string key="NSResourceName">NSMenuCheckmark</string>
-						</object>
-						<object class="NSCustomResource" key="NSMixedImage" id="897496305">
-							<string key="NSClassName">NSImage</string>
-							<string key="NSResourceName">NSMenuMixedState</string>
-						</object>
-						<string key="NSAction">submenuAction:</string>
-						<reference key="NSTarget" ref="110575045"/>
-						<object class="NSMenu" key="NSSubmenu" id="110575045">
-							<string key="NSTitle">Imagr</string>
-							<array class="NSMutableArray" key="NSMenuItems">
-								<object class="NSMenuItem" id="238522557">
-									<reference key="NSMenu" ref="110575045"/>
-									<string key="NSTitle">About Imagr</string>
-									<string key="NSKeyEquiv"/>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<reference key="NSOnImage" ref="715147791"/>
-									<reference key="NSMixedImage" ref="897496305"/>
-								</object>
-								<object class="NSMenuItem" id="481834944">
-									<reference key="NSMenu" ref="110575045"/>
-									<bool key="NSIsDisabled">YES</bool>
-									<bool key="NSIsSeparator">YES</bool>
-									<string key="NSTitle"/>
-									<string key="NSKeyEquiv"/>
-									<int key="NSKeyEquivModMask">1048576</int>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<reference key="NSOnImage" ref="715147791"/>
-									<reference key="NSMixedImage" ref="897496305"/>
-								</object>
-								<object class="NSMenuItem" id="1046388886">
-									<reference key="NSMenu" ref="110575045"/>
-									<string key="NSTitle">Services</string>
-									<string key="NSKeyEquiv"/>
-									<int key="NSKeyEquivModMask">1048576</int>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<reference key="NSOnImage" ref="715147791"/>
-									<reference key="NSMixedImage" ref="897496305"/>
-									<string key="NSAction">submenuAction:</string>
-									<reference key="NSTarget" ref="752062318"/>
-									<object class="NSMenu" key="NSSubmenu" id="752062318">
-										<string key="NSTitle">Services</string>
-										<array class="NSMutableArray" key="NSMenuItems"/>
-										<string key="NSName">_NSServicesMenu</string>
-									</object>
-								</object>
-								<object class="NSMenuItem" id="646227648">
-									<reference key="NSMenu" ref="110575045"/>
-									<bool key="NSIsDisabled">YES</bool>
-									<bool key="NSIsSeparator">YES</bool>
-									<string key="NSTitle"/>
-									<string key="NSKeyEquiv"/>
-									<int key="NSKeyEquivModMask">1048576</int>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<reference key="NSOnImage" ref="715147791"/>
-									<reference key="NSMixedImage" ref="897496305"/>
-								</object>
-								<object class="NSMenuItem" id="262723819">
-									<reference key="NSMenu" ref="110575045"/>
-									<bool key="NSIsDisabled">YES</bool>
-									<string key="NSTitle">Reload Workflows</string>
-									<string key="NSKeyEquiv">r</string>
-									<int key="NSKeyEquivModMask">1048576</int>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<reference key="NSOnImage" ref="715147791"/>
-									<reference key="NSMixedImage" ref="897496305"/>
-								</object>
-								<object class="NSMenuItem" id="329851051">
-									<reference key="NSMenu" ref="110575045"/>
-									<bool key="NSIsDisabled">YES</bool>
-									<bool key="NSIsSeparator">YES</bool>
-									<string key="NSTitle"/>
-									<string key="NSKeyEquiv"/>
-									<int key="NSKeyEquivModMask">1048576</int>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<reference key="NSOnImage" ref="715147791"/>
-									<reference key="NSMixedImage" ref="897496305"/>
-								</object>
-								<object class="NSMenuItem" id="755159360">
-									<reference key="NSMenu" ref="110575045"/>
-									<string key="NSTitle">Hide Imagr</string>
-									<string key="NSKeyEquiv">h</string>
-									<int key="NSKeyEquivModMask">1048576</int>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<reference key="NSOnImage" ref="715147791"/>
-									<reference key="NSMixedImage" ref="897496305"/>
-								</object>
-								<object class="NSMenuItem" id="342932134">
-									<reference key="NSMenu" ref="110575045"/>
-									<string key="NSTitle">Hide Others</string>
-									<string key="NSKeyEquiv">h</string>
-									<int key="NSKeyEquivModMask">1572864</int>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<reference key="NSOnImage" ref="715147791"/>
-									<reference key="NSMixedImage" ref="897496305"/>
-								</object>
-								<object class="NSMenuItem" id="908899353">
-									<reference key="NSMenu" ref="110575045"/>
-									<string key="NSTitle">Show All</string>
-									<string key="NSKeyEquiv"/>
-									<int key="NSKeyEquivModMask">1048576</int>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<reference key="NSOnImage" ref="715147791"/>
-									<reference key="NSMixedImage" ref="897496305"/>
-								</object>
-								<object class="NSMenuItem" id="1056857174">
-									<reference key="NSMenu" ref="110575045"/>
-									<bool key="NSIsDisabled">YES</bool>
-									<bool key="NSIsSeparator">YES</bool>
-									<string key="NSTitle"/>
-									<string key="NSKeyEquiv"/>
-									<int key="NSKeyEquivModMask">1048576</int>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<reference key="NSOnImage" ref="715147791"/>
-									<reference key="NSMixedImage" ref="897496305"/>
-								</object>
-								<object class="NSMenuItem" id="632727374">
-									<reference key="NSMenu" ref="110575045"/>
-									<string key="NSTitle">Quit Imagr</string>
-									<string key="NSKeyEquiv">q</string>
-									<int key="NSKeyEquivModMask">1048576</int>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<reference key="NSOnImage" ref="715147791"/>
-									<reference key="NSMixedImage" ref="897496305"/>
-								</object>
-							</array>
-							<string key="NSName">_NSAppleMenu</string>
-							<bool key="NSNoAutoenable">YES</bool>
-						</object>
-					</object>
-					<object class="NSMenuItem" id="210252055">
-						<reference key="NSMenu" ref="649796088"/>
-						<string key="NSTitle">Utilities</string>
-						<string key="NSKeyEquiv"/>
-						<int key="NSKeyEquivModMask">1048576</int>
-						<int key="NSMnemonicLoc">2147483647</int>
-						<reference key="NSOnImage" ref="715147791"/>
-						<reference key="NSMixedImage" ref="897496305"/>
-						<string key="NSAction">submenuAction:</string>
-						<reference key="NSTarget" ref="348727561"/>
-						<object class="NSMenu" key="NSSubmenu" id="348727561">
-							<string key="NSTitle">Utilities</string>
-							<array class="NSMutableArray" key="NSMenuItems"/>
-						</object>
-					</object>
-					<object class="NSMenuItem" id="391199113">
-						<reference key="NSMenu" ref="649796088"/>
-						<string key="NSTitle">Help</string>
-						<string key="NSKeyEquiv"/>
-						<int key="NSKeyEquivModMask">1048576</int>
-						<int key="NSMnemonicLoc">2147483647</int>
-						<reference key="NSOnImage" ref="715147791"/>
-						<reference key="NSMixedImage" ref="897496305"/>
-						<string key="NSAction">submenuAction:</string>
-						<reference key="NSTarget" ref="374024848"/>
-						<object class="NSMenu" key="NSSubmenu" id="374024848">
-							<string key="NSTitle">Help</string>
-							<array class="NSMutableArray" key="NSMenuItems">
-								<object class="NSMenuItem" id="238773614">
-									<reference key="NSMenu" ref="374024848"/>
-									<string key="NSTitle">Imagr Help</string>
-									<string key="NSKeyEquiv">?</string>
-									<int key="NSKeyEquivModMask">1048576</int>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<reference key="NSOnImage" ref="715147791"/>
-									<reference key="NSMixedImage" ref="897496305"/>
-								</object>
-							</array>
-						</object>
-					</object>
-				</array>
-				<string key="NSName">_NSMainMenu</string>
-				<bool key="NSNoAutoenable">YES</bool>
-			</object>
-			<object class="NSCustomObject" id="610635028">
-				<string key="NSClassName">AppDelegate</string>
-			</object>
-			<object class="NSCustomObject" id="15635064">
-				<string key="NSClassName">NSFontManager</string>
-			</object>
-			<object class="NSCustomObject" id="1061118799">
-				<string key="NSClassName">MainController</string>
-			</object>
-			<object class="NSWindowTemplate" id="125443915">
-				<int key="NSWindowStyleMask">1</int>
-				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{0, 274}, {697, 503}}</string>
-				<int key="NSWTFlags">1886913536</int>
-				<string key="NSWindowTitle">Imagr</string>
-				<string key="NSWindowClass">NSWindow</string>
-				<nil key="NSViewClass"/>
-				<nil key="NSUserInterfaceItemIdentifier"/>
-				<object class="NSView" key="NSWindowView" id="367560152">
-					<reference key="NSNextResponder"/>
-					<int key="NSvFlags">4352</int>
-					<array class="NSMutableArray" key="NSSubviews">
-						<object class="NSImageView" id="461199512">
-							<reference key="NSNextResponder" ref="367560152"/>
-							<int key="NSvFlags">268</int>
-							<array class="NSMutableArray" key="NSSubviews"/>
-							<set class="NSMutableSet" key="NSDragTypes">
-								<string>Apple PDF pasteboard type</string>
-								<string>Apple PICT pasteboard type</string>
-								<string>Apple PNG pasteboard type</string>
-								<string>NSFilenamesPboardType</string>
-								<string>NeXT Encapsulated PostScript v1.2 pasteboard type</string>
-								<string>NeXT TIFF v4.0 pasteboard type</string>
-							</set>
-							<string key="NSFrame">{{-77, -1}, {457, 502}}</string>
-							<reference key="NSSuperview" ref="367560152"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView"/>
-							<double key="NSViewAlphaValue">0.5</double>
-							<string key="NSHuggingPriority">{251, 251}</string>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSImageCell" key="NSCell" id="283991686">
-								<int key="NSCellFlags">0</int>
-								<int key="NSCellFlags2">33554432</int>
-								<object class="NSCustomResource" key="NSContents">
-									<string key="NSClassName">NSImage</string>
-									<string key="NSResourceName">imagr_icon</string>
-								</object>
-								<int key="NSAlign">0</int>
-								<int key="NSScale">3</int>
-								<int key="NSStyle">0</int>
-								<bool key="NSAnimates">NO</bool>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-							<bool key="NSEditable">YES</bool>
-						</object>
-						<object class="NSTabView" id="159778808">
-							<reference key="NSNextResponder" ref="367560152"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{7, 8}, {680, 487}}</string>
-							<reference key="NSSuperview" ref="367560152"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="22249470"/>
-							<string key="NSReuseIdentifierKey">_NS:9</string>
-							<array class="NSMutableArray" key="NSTabViewItems">
-								<object class="NSTabViewItem" id="671669968">
-									<object class="NSView" key="NSView" id="366981630">
-										<nil key="NSNextResponder"/>
-										<int key="NSvFlags">274</int>
-										<array class="NSMutableArray" key="NSSubviews">
-											<object class="NSProgressIndicator" id="958872179">
-												<reference key="NSNextResponder" ref="366981630"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{324, 227}, {32, 32}}</string>
-												<reference key="NSSuperview" ref="366981630"/>
-												<reference key="NSNextKeyView" ref="159778808"/>
-												<string key="NSReuseIdentifierKey">_NS:1431</string>
-												<string key="NSHuggingPriority">{750, 750}</string>
-												<int key="NSpiFlags">28686</int>
-												<double key="NSMaxValue">100</double>
-											</object>
-											<object class="NSTextField" id="134608693">
-												<reference key="NSNextResponder" ref="366981630"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{163, 267}, {354, 17}}</string>
-												<reference key="NSSuperview" ref="366981630"/>
-												<reference key="NSNextKeyView" ref="958872179"/>
-												<string key="NSReuseIdentifierKey">_NS:526</string>
-												<string key="NSHuggingPriority">{251, 750}</string>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="982909434">
-													<int key="NSCellFlags">68157504</int>
-													<int key="NSCellFlags2">138413056</int>
-													<string key="NSContents">Starting...</string>
-													<object class="NSFont" key="NSSupport" id="881900057">
-														<bool key="IBIsSystemFont">YES</bool>
-														<double key="NSSize">13</double>
-														<int key="NSfFlags">1044</int>
-													</object>
-													<string key="NSCellIdentifier">_NS:526</string>
-													<reference key="NSControlView" ref="134608693"/>
-													<object class="NSColor" key="NSBackgroundColor" id="607809683">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">controlColor</string>
-														<object class="NSColor" key="NSColor" id="907392743">
-															<int key="NSColorSpace">3</int>
-															<bytes key="NSWhite">MC42NjY2NjY2NjY3AA</bytes>
-														</object>
-													</object>
-													<object class="NSColor" key="NSTextColor" id="363351792">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">labelColor</string>
-														<object class="NSColor" key="NSColor" id="77445269">
-															<int key="NSColorSpace">3</int>
-															<bytes key="NSWhite">MAA</bytes>
-														</object>
-													</object>
-												</object>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-												<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-											</object>
-										</array>
-										<string key="NSFrameSize">{680, 487}</string>
-										<reference key="NSNextKeyView" ref="134608693"/>
-									</object>
-									<string key="NSLabel">Intro</string>
-									<reference key="NSColor" ref="607809683"/>
-									<reference key="NSTabView" ref="159778808"/>
-								</object>
-								<object class="NSTabViewItem" id="632038340">
-									<string key="NSIdentifier">1</string>
-									<object class="NSView" key="NSView" id="482842367">
-										<nil key="NSNextResponder"/>
-										<int key="NSvFlags">274</int>
-										<array class="NSMutableArray" key="NSSubviews">
-											<object class="NSTextField" id="955668471">
-												<reference key="NSNextResponder" ref="482842367"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{327, 324}, {354, 17}}</string>
-												<reference key="NSSuperview" ref="482842367"/>
-												<reference key="NSNextKeyView" ref="567205958"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="500681499">
-													<int key="NSCellFlags">68157504</int>
-													<int key="NSCellFlags2">272630784</int>
-													<string key="NSContents">Enter Deployment Password</string>
-													<reference key="NSSupport" ref="881900057"/>
-													<reference key="NSControlView" ref="955668471"/>
-													<reference key="NSBackgroundColor" ref="607809683"/>
-													<object class="NSColor" key="NSTextColor" id="499429957">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">controlTextColor</string>
-														<reference key="NSColor" ref="77445269"/>
-													</object>
-												</object>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-												<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-											</object>
-											<object class="NSSecureTextField" id="567205958">
-												<reference key="NSNextResponder" ref="482842367"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{329, 279}, {288, 37}}</string>
-												<reference key="NSSuperview" ref="482842367"/>
-												<reference key="NSNextKeyView" ref="70639366"/>
-												<int key="NSTag">1</int>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSSecureTextFieldCell" key="NSCell" id="755388124">
-													<int key="NSCellFlags">342884417</int>
-													<int key="NSCellFlags2">268436480</int>
-													<string key="NSContents"/>
-													<object class="NSFont" key="NSSupport">
-														<bool key="IBIsSystemFont">YES</bool>
-														<double key="NSSize">25</double>
-														<int key="NSfFlags">1044</int>
-													</object>
-													<reference key="NSControlView" ref="567205958"/>
-													<bool key="NSDrawsBackground">YES</bool>
-													<object class="NSColor" key="NSBackgroundColor" id="973932872">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">textBackgroundColor</string>
-														<object class="NSColor" key="NSColor">
-															<int key="NSColorSpace">3</int>
-															<bytes key="NSWhite">MQA</bytes>
-														</object>
-													</object>
-													<object class="NSColor" key="NSTextColor" id="417760897">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">textColor</string>
-														<reference key="NSColor" ref="77445269"/>
-													</object>
-													<array key="NSAllowedInputLocales">
-														<string>NSAllRomanInputSourcesLocaleIdentifier</string>
-													</array>
-												</object>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-												<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-											</object>
-											<object class="NSButton" id="70639366">
-												<reference key="NSNextResponder" ref="482842367"/>
-												<int key="NSvFlags">268</int>
-												<array class="NSMutableArray" key="NSSubviews"/>
-												<string key="NSFrame">{{536, 243}, {87, 32}}</string>
-												<reference key="NSSuperview" ref="482842367"/>
-												<reference key="NSNextKeyView"/>
-												<string key="NSHuggingPriority">{250, 750}</string>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="1048853569">
-													<int key="NSCellFlags">67108864</int>
-													<int key="NSCellFlags2">134217728</int>
-													<string key="NSContents">Login</string>
-													<reference key="NSSupport" ref="881900057"/>
-													<reference key="NSControlView" ref="70639366"/>
-													<int key="NSButtonFlags">-2038284288</int>
-													<int key="NSButtonFlags2">129</int>
-													<object class="NSFont" key="NSAlternateImage" id="378956934">
-														<string key="NSName">.LucidaGrandeUI</string>
-														<double key="NSSize">13</double>
-														<int key="NSfFlags">16</int>
-													</object>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">400</int>
-													<int key="NSPeriodicInterval">75</int>
-												</object>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-											</object>
-											<object class="NSTextField" id="705431801">
-												<reference key="NSNextResponder" ref="482842367"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{332, 225}, {283, 17}}</string>
-												<reference key="NSSuperview" ref="482842367"/>
-												<reference key="NSNextKeyView" ref="159778808"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="942098964">
-													<int key="NSCellFlags">68157504</int>
-													<int key="NSCellFlags2">138413056</int>
-													<string key="NSContents"/>
-													<reference key="NSSupport" ref="881900057"/>
-													<reference key="NSControlView" ref="705431801"/>
-													<reference key="NSBackgroundColor" ref="607809683"/>
-													<object class="NSColor" key="NSTextColor">
-														<int key="NSColorSpace">1</int>
-														<bytes key="NSRGB">MC42OTYyNjc4MzI5IDAgMC4wMDgyMDgwNjIwNjUAA</bytes>
-													</object>
-												</object>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-												<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-											</object>
-										</array>
-										<string key="NSFrameSize">{680, 487}</string>
-										<reference key="NSNextKeyView" ref="955668471"/>
-										<string key="NSReuseIdentifierKey">_NS:11</string>
-									</object>
-									<string key="NSLabel">Login</string>
-									<reference key="NSColor" ref="607809683"/>
-									<reference key="NSTabView" ref="159778808"/>
-								</object>
-								<object class="NSTabViewItem" id="2383049">
-									<string key="NSIdentifier">2</string>
-									<object class="NSView" key="NSView" id="22249470">
-										<reference key="NSNextResponder" ref="159778808"/>
-										<int key="NSvFlags">274</int>
-										<array class="NSMutableArray" key="NSSubviews">
-											<object class="NSButton" id="300259507">
-												<reference key="NSNextResponder" ref="22249470"/>
-												<int key="NSvFlags">256</int>
-												<array class="NSMutableArray" key="NSSubviews"/>
-												<string key="NSFrame">{{112, 13}, {134, 32}}</string>
-												<reference key="NSSuperview" ref="22249470"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView"/>
-												<string key="NSHuggingPriority">{250, 750}</string>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="389625284">
-													<int key="NSCellFlags">67108864</int>
-													<int key="NSCellFlags2">134217728</int>
-													<string key="NSContents">Cancel &amp; Restart</string>
-													<reference key="NSSupport" ref="881900057"/>
-													<reference key="NSControlView" ref="300259507"/>
-													<int key="NSButtonFlags">-2038284288</int>
-													<int key="NSButtonFlags2">129</int>
-													<reference key="NSAlternateImage" ref="378956934"/>
-													<string key="NSAlternateContents"/>
-													<string type="base64-UTF8" key="NSKeyEquivalent">Gw</string>
-													<int key="NSPeriodicDelay">400</int>
-													<int key="NSPeriodicInterval">75</int>
-												</object>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-											</object>
-											<object class="NSButton" id="1035765763">
-												<reference key="NSNextResponder" ref="22249470"/>
-												<int key="NSvFlags">268</int>
-												<array class="NSMutableArray" key="NSSubviews"/>
-												<string key="NSFrame">{{442, 13}, {126, 32}}</string>
-												<reference key="NSSuperview" ref="22249470"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView"/>
-												<string key="NSReuseIdentifierKey">_NS:9</string>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="837689253">
-													<int key="NSCellFlags">67108864</int>
-													<int key="NSCellFlags2">134217728</int>
-													<string key="NSContents">Run Workflow</string>
-													<reference key="NSSupport" ref="881900057"/>
-													<string key="NSCellIdentifier">_NS:9</string>
-													<reference key="NSControlView" ref="1035765763"/>
-													<int key="NSButtonFlags">-2038284288</int>
-													<int key="NSButtonFlags2">129</int>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-											</object>
-											<object class="NSPopUpButton" id="555067212">
-												<reference key="NSNextResponder" ref="22249470"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{243, 362}, {322, 26}}</string>
-												<reference key="NSSuperview" ref="22249470"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="614889614"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSPopUpButtonCell" key="NSCell" id="862068476">
-													<int key="NSCellFlags">-2076180416</int>
-													<int key="NSCellFlags2">2048</int>
-													<object class="NSFont" key="NSSupport" id="641322834">
-														<bool key="IBIsSystemFont">YES</bool>
-														<double key="NSSize">13</double>
-														<int key="NSfFlags">1301</int>
-													</object>
-													<reference key="NSControlView" ref="555067212"/>
-													<int key="NSButtonFlags">109199360</int>
-													<int key="NSButtonFlags2">129</int>
-													<reference key="NSAlternateImage" ref="378956934"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">400</int>
-													<int key="NSPeriodicInterval">75</int>
-													<nil key="NSMenuItem"/>
-													<bool key="NSMenuItemRespectAlignment">YES</bool>
-													<object class="NSMenu" key="NSMenu" id="374469571">
-														<string key="NSTitle"/>
-														<array class="NSMutableArray" key="NSMenuItems">
-															<object class="NSMenuItem" id="697511182">
-																<reference key="NSMenu" ref="374469571"/>
-																<string key="NSTitle">Select target volume</string>
-																<string key="NSKeyEquiv"/>
-																<int key="NSKeyEquivModMask">1048576</int>
-																<int key="NSMnemonicLoc">2147483647</int>
-																<reference key="NSOnImage" ref="715147791"/>
-																<reference key="NSMixedImage" ref="897496305"/>
-																<string key="NSAction">_popUpItemAction:</string>
-																<reference key="NSTarget" ref="862068476"/>
-															</object>
-															<object class="NSMenuItem" id="1016311381">
-																<reference key="NSMenu" ref="374469571"/>
-																<string key="NSTitle">Item 2</string>
-																<string key="NSKeyEquiv"/>
-																<int key="NSKeyEquivModMask">1048576</int>
-																<int key="NSMnemonicLoc">2147483647</int>
-																<reference key="NSOnImage" ref="715147791"/>
-																<reference key="NSMixedImage" ref="897496305"/>
-																<string key="NSAction">_popUpItemAction:</string>
-																<reference key="NSTarget" ref="862068476"/>
-															</object>
-															<object class="NSMenuItem" id="509731998">
-																<reference key="NSMenu" ref="374469571"/>
-																<string key="NSTitle">Item 3</string>
-																<string key="NSKeyEquiv"/>
-																<int key="NSKeyEquivModMask">1048576</int>
-																<int key="NSMnemonicLoc">2147483647</int>
-																<reference key="NSOnImage" ref="715147791"/>
-																<reference key="NSMixedImage" ref="897496305"/>
-																<string key="NSAction">_popUpItemAction:</string>
-																<reference key="NSTarget" ref="862068476"/>
-															</object>
-														</array>
-													</object>
-													<int key="NSSelectedIndex">-1</int>
-													<int key="NSPreferredEdge">1</int>
-													<bool key="NSUsesItemFromMenu">YES</bool>
-													<bool key="NSAltersState">YES</bool>
-													<int key="NSArrowPosition">2</int>
-												</object>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-											</object>
-											<object class="NSPopUpButton" id="72689598">
-												<reference key="NSNextResponder" ref="22249470"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{243, 331}, {322, 26}}</string>
-												<reference key="NSSuperview" ref="22249470"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="139496358"/>
-												<string key="NSReuseIdentifierKey">_NS:9</string>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSPopUpButtonCell" key="NSCell" id="67273808">
-													<int key="NSCellFlags">71303232</int>
-													<int key="NSCellFlags2">2048</int>
-													<reference key="NSSupport" ref="641322834"/>
-													<string key="NSCellIdentifier">_NS:9</string>
-													<reference key="NSControlView" ref="72689598"/>
-													<int key="NSButtonFlags">109199360</int>
-													<int key="NSButtonFlags2">129</int>
-													<reference key="NSAlternateImage" ref="378956934"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">400</int>
-													<int key="NSPeriodicInterval">75</int>
-													<nil key="NSMenuItem"/>
-													<bool key="NSMenuItemRespectAlignment">YES</bool>
-													<object class="NSMenu" key="NSMenu" id="1046540592">
-														<string key="NSTitle"/>
-														<array class="NSMutableArray" key="NSMenuItems">
-															<object class="NSMenuItem" id="332266605">
-																<reference key="NSMenu" ref="1046540592"/>
-																<string key="NSTitle">Select workflow</string>
-																<string key="NSKeyEquiv"/>
-																<int key="NSKeyEquivModMask">1048576</int>
-																<int key="NSMnemonicLoc">2147483647</int>
-																<reference key="NSOnImage" ref="715147791"/>
-																<reference key="NSMixedImage" ref="897496305"/>
-																<string key="NSAction">_popUpItemAction:</string>
-																<reference key="NSTarget" ref="67273808"/>
-															</object>
-															<object class="NSMenuItem" id="547346547">
-																<reference key="NSMenu" ref="1046540592"/>
-																<string key="NSTitle">Item 2</string>
-																<string key="NSKeyEquiv"/>
-																<int key="NSKeyEquivModMask">1048576</int>
-																<int key="NSMnemonicLoc">2147483647</int>
-																<reference key="NSOnImage" ref="715147791"/>
-																<reference key="NSMixedImage" ref="897496305"/>
-																<string key="NSAction">_popUpItemAction:</string>
-																<reference key="NSTarget" ref="67273808"/>
-															</object>
-															<object class="NSMenuItem" id="254823087">
-																<reference key="NSMenu" ref="1046540592"/>
-																<string key="NSTitle">Item 3</string>
-																<string key="NSKeyEquiv"/>
-																<int key="NSKeyEquivModMask">1048576</int>
-																<int key="NSMnemonicLoc">2147483647</int>
-																<reference key="NSOnImage" ref="715147791"/>
-																<reference key="NSMixedImage" ref="897496305"/>
-																<string key="NSAction">_popUpItemAction:</string>
-																<reference key="NSTarget" ref="67273808"/>
-															</object>
-														</array>
-													</object>
-													<int key="NSSelectedIndex">-1</int>
-													<int key="NSPreferredEdge">1</int>
-													<bool key="NSUsesItemFromMenu">YES</bool>
-													<bool key="NSAltersState">YES</bool>
-													<int key="NSArrowPosition">2</int>
-												</object>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-											</object>
-											<object class="NSScrollView" id="37250636">
-												<reference key="NSNextResponder" ref="22249470"/>
-												<int key="NSvFlags">4352</int>
-												<array class="NSMutableArray" key="NSSubviews">
-													<object class="NSClipView" id="1019754332">
-														<reference key="NSNextResponder" ref="37250636"/>
-														<int key="NSvFlags">2322</int>
-														<array class="NSMutableArray" key="NSSubviews">
-															<object class="NSTextView" id="54294484">
-																<reference key="NSNextResponder" ref="1019754332"/>
-																<int key="NSvFlags">2322</int>
-																<string key="NSFrameSize">{442, 231}</string>
-																<reference key="NSSuperview" ref="1019754332"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="375661957"/>
-																<string key="NSReuseIdentifierKey">_NS:13</string>
-																<object class="NSTextContainer" key="NSTextContainer" id="784039287">
-																	<object class="NSLayoutManager" key="NSLayoutManager">
-																		<object class="NSTextStorage" key="NSTextStorage">
-																			<object class="NSMutableString" key="NSString">
-																				<characters key="NS.bytes"/>
-																			</object>
-																			<nil key="NSDelegate"/>
-																		</object>
-																		<array class="NSMutableArray" key="NSTextContainers">
-																			<reference ref="784039287"/>
-																		</array>
-																		<int key="NSLMFlags">166</int>
-																		<nil key="NSDelegate"/>
-																	</object>
-																	<reference key="NSTextView" ref="54294484"/>
-																	<double key="NSWidth">442</double>
-																	<int key="NSTCFlags">1</int>
-																</object>
-																<object class="NSTextViewSharedData" key="NSSharedData">
-																	<int key="NSFlags">10340</int>
-																	<int key="NSTextCheckingTypes">0</int>
-																	<nil key="NSMarkedAttributes"/>
-																	<object class="NSColor" key="NSBackgroundColor">
-																		<int key="NSColorSpace">3</int>
-																		<bytes key="NSWhite">MSAwAA</bytes>
-																	</object>
-																	<dictionary key="NSSelectedAttributes">
-																		<object class="NSColor" key="NSBackgroundColor">
-																			<int key="NSColorSpace">6</int>
-																			<string key="NSCatalogName">System</string>
-																			<string key="NSColorName">selectedTextBackgroundColor</string>
-																			<reference key="NSColor" ref="907392743"/>
-																		</object>
-																		<object class="NSColor" key="NSColor">
-																			<int key="NSColorSpace">6</int>
-																			<string key="NSCatalogName">System</string>
-																			<string key="NSColorName">selectedTextColor</string>
-																			<reference key="NSColor" ref="77445269"/>
-																		</object>
-																	</dictionary>
-																	<reference key="NSInsertionColor" ref="499429957"/>
-																	<dictionary key="NSLinkAttributes">
-																		<object class="NSColor" key="NSColor">
-																			<int key="NSColorSpace">1</int>
-																			<bytes key="NSRGB">MCAwIDEAA</bytes>
-																		</object>
-																		<object class="NSCursor" key="NSCursor">
-																			<string key="NSHotSpot">{8, -8}</string>
-																			<int key="NSCursorType">13</int>
-																		</object>
-																		<integer value="1" key="NSUnderline"/>
-																	</dictionary>
-																	<nil key="NSDefaultParagraphStyle"/>
-																	<nil key="NSTextFinder"/>
-																	<int key="NSPreferredTextFinderStyle">1</int>
-																</object>
-																<int key="NSTVFlags">4</int>
-																<string key="NSMaxSize">{546, 10000000}</string>
-																<nil key="NSDelegate"/>
-															</object>
-														</array>
-														<string key="NSFrame">{{1, 1}, {442, 231}}</string>
-														<reference key="NSSuperview" ref="37250636"/>
-														<reference key="NSWindow"/>
-														<reference key="NSNextKeyView" ref="54294484"/>
-														<string key="NSReuseIdentifierKey">_NS:11</string>
-														<reference key="NSDocView" ref="54294484"/>
-														<object class="NSColor" key="NSBGColor">
-															<int key="NSColorSpace">3</int>
-															<bytes key="NSWhite">MSAwAA</bytes>
-														</object>
-														<object class="NSCursor" key="NSCursor">
-															<string key="NSHotSpot">{5, 5}</string>
-															<int key="NSCursorType">0</int>
-														</object>
-														<int key="NScvFlags">6</int>
-													</object>
-													<object class="NSScroller" id="375661957">
-														<reference key="NSNextResponder" ref="37250636"/>
-														<int key="NSvFlags">256</int>
-														<string key="NSFrame">{{427, 1}, {16, 231}}</string>
-														<reference key="NSSuperview" ref="37250636"/>
-														<reference key="NSWindow"/>
-														<reference key="NSNextKeyView" ref="300259507"/>
-														<string key="NSReuseIdentifierKey">_NS:85</string>
-														<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-														<reference key="NSTarget" ref="37250636"/>
-														<string key="NSAction">_doScroller:</string>
-														<double key="NSCurValue">1</double>
-														<double key="NSPercent">0.85256409645080566</double>
-													</object>
-													<object class="NSScroller" id="723861177">
-														<reference key="NSNextResponder" ref="37250636"/>
-														<int key="NSvFlags">-2147483392</int>
-														<string key="NSFrame">{{-100, -100}, {87, 18}}</string>
-														<reference key="NSSuperview" ref="37250636"/>
-														<reference key="NSWindow"/>
-														<reference key="NSNextKeyView" ref="1019754332"/>
-														<string key="NSReuseIdentifierKey">_NS:33</string>
-														<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-														<int key="NSsFlags">1</int>
-														<reference key="NSTarget" ref="37250636"/>
-														<string key="NSAction">_doScroller:</string>
-														<double key="NSCurValue">1</double>
-														<double key="NSPercent">0.94565218687057495</double>
-													</object>
-												</array>
-												<string key="NSFrame">{{118, 61}, {444, 233}}</string>
-												<reference key="NSSuperview" ref="22249470"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="723861177"/>
-												<string key="NSReuseIdentifierKey">_NS:9</string>
-												<int key="NSsFlags">133138</int>
-												<reference key="NSVScroller" ref="375661957"/>
-												<reference key="NSHScroller" ref="723861177"/>
-												<reference key="NSContentView" ref="1019754332"/>
-												<double key="NSMinMagnification">0.25</double>
-												<double key="NSMaxMagnification">4</double>
-												<double key="NSMagnification">1</double>
-											</object>
-											<object class="NSButton" id="139496358">
-												<reference key="NSNextResponder" ref="22249470"/>
-												<int key="NSvFlags">256</int>
-												<array class="NSMutableArray" key="NSSubviews"/>
-												<string key="NSFrame">{{417, 296}, {151, 32}}</string>
-												<reference key="NSSuperview" ref="22249470"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView"/>
-												<string key="NSHuggingPriority">{250, 750}</string>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="164015895">
-													<int key="NSCellFlags">67108864</int>
-													<int key="NSCellFlags2">134217728</int>
-													<string key="NSContents">Reload Workflows</string>
-													<reference key="NSSupport" ref="881900057"/>
-													<reference key="NSControlView" ref="139496358"/>
-													<int key="NSButtonFlags">-2038284288</int>
-													<int key="NSButtonFlags2">129</int>
-													<reference key="NSAlternateImage" ref="378956934"/>
-													<string key="NSAlternateContents"/>
-													<string type="base64-UTF8" key="NSKeyEquivalent">Gw</string>
-													<int key="NSPeriodicDelay">400</int>
-													<int key="NSPeriodicInterval">75</int>
-												</object>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-											</object>
-											<object class="NSTextField" id="127573865">
-												<reference key="NSNextResponder" ref="22249470"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{116, 367}, {97, 17}}</string>
-												<reference key="NSSuperview" ref="22249470"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="555067212"/>
-												<string key="NSHuggingPriority">{251, 750}</string>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="481495187">
-													<int key="NSCellFlags">68157504</int>
-													<int key="NSCellFlags2">272630784</int>
-													<string key="NSContents">Choose Target:</string>
-													<reference key="NSSupport" ref="881900057"/>
-													<reference key="NSControlView" ref="127573865"/>
-													<reference key="NSBackgroundColor" ref="607809683"/>
-													<reference key="NSTextColor" ref="363351792"/>
-												</object>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-												<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-											</object>
-											<object class="NSTextField" id="614889614">
-												<reference key="NSNextResponder" ref="22249470"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{116, 336}, {116, 17}}</string>
-												<reference key="NSSuperview" ref="22249470"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="72689598"/>
-												<string key="NSHuggingPriority">{251, 750}</string>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="365765916">
-													<int key="NSCellFlags">68157504</int>
-													<int key="NSCellFlags2">272630784</int>
-													<string key="NSContents">Choose Workflow:</string>
-													<reference key="NSSupport" ref="881900057"/>
-													<reference key="NSControlView" ref="614889614"/>
-													<reference key="NSBackgroundColor" ref="607809683"/>
-													<reference key="NSTextColor" ref="363351792"/>
-												</object>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-												<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-											</object>
-										</array>
-										<string key="NSFrameSize">{680, 487}</string>
-										<reference key="NSSuperview" ref="159778808"/>
-										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="127573865"/>
-										<string key="NSReuseIdentifierKey">_NS:28</string>
-									</object>
-									<string key="NSLabel">Main</string>
-									<reference key="NSColor" ref="607809683"/>
-									<reference key="NSTabView" ref="159778808"/>
-								</object>
-								<object class="NSTabViewItem" id="760072728">
-									<string key="NSIdentifier">2</string>
-									<object class="NSView" key="NSView" id="344944858">
-										<nil key="NSNextResponder"/>
-										<int key="NSvFlags">274</int>
-										<array class="NSMutableArray" key="NSSubviews"/>
-										<string key="NSFrameSize">{680, 487}</string>
-										<reference key="NSNextKeyView" ref="159778808"/>
-										<string key="NSReuseIdentifierKey">_NS:28</string>
-									</object>
-									<string key="NSLabel">Main</string>
-									<reference key="NSColor" ref="607809683"/>
-									<reference key="NSTabView" ref="159778808"/>
-								</object>
-								<object class="NSTabViewItem" id="293211172">
-									<string key="NSIdentifier">2</string>
-									<object class="NSView" key="NSView" id="50591286">
-										<nil key="NSNextResponder"/>
-										<int key="NSvFlags">274</int>
-										<array class="NSMutableArray" key="NSSubviews">
-											<object class="NSTextField" id="857597622">
-												<reference key="NSNextResponder" ref="50591286"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{242, 373}, {106, 17}}</string>
-												<reference key="NSSuperview" ref="50591286"/>
-												<reference key="NSNextKeyView" ref="238691935"/>
-												<string key="NSReuseIdentifierKey">_NS:526</string>
-												<string key="NSHuggingPriority">{251, 750}</string>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="324106665">
-													<int key="NSCellFlags">68157504</int>
-													<int key="NSCellFlags2">272630784</int>
-													<string key="NSContents">Computer Name</string>
-													<reference key="NSSupport" ref="881900057"/>
-													<string key="NSCellIdentifier">_NS:526</string>
-													<reference key="NSControlView" ref="857597622"/>
-													<reference key="NSBackgroundColor" ref="607809683"/>
-													<reference key="NSTextColor" ref="363351792"/>
-												</object>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-												<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-											</object>
-											<object class="NSTextField" id="238691935">
-												<reference key="NSNextResponder" ref="50591286"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{244, 328}, {288, 37}}</string>
-												<reference key="NSSuperview" ref="50591286"/>
-												<reference key="NSNextKeyView" ref="99115794"/>
-												<string key="NSReuseIdentifierKey">_NS:9</string>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="744391400">
-													<int key="NSCellFlags">-1804599231</int>
-													<int key="NSCellFlags2">272630784</int>
-													<string key="NSContents"/>
-													<object class="NSFont" key="NSSupport">
-														<bool key="IBIsSystemFont">YES</bool>
-														<double key="NSSize">25</double>
-														<int key="NSfFlags">1044</int>
-													</object>
-													<string key="NSCellIdentifier">_NS:9</string>
-													<reference key="NSControlView" ref="238691935"/>
-													<bool key="NSDrawsBackground">YES</bool>
-													<reference key="NSBackgroundColor" ref="973932872"/>
-													<reference key="NSTextColor" ref="417760897"/>
-												</object>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-												<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-											</object>
-											<object class="NSButton" id="99115794">
-												<reference key="NSNextResponder" ref="50591286"/>
-												<int key="NSvFlags">268</int>
-												<array class="NSMutableArray" key="NSSubviews"/>
-												<string key="NSFrame">{{372, 292}, {166, 32}}</string>
-												<reference key="NSSuperview" ref="50591286"/>
-												<reference key="NSNextKeyView"/>
-												<string key="NSReuseIdentifierKey">_NS:9</string>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="1003346449">
-													<int key="NSCellFlags">67108864</int>
-													<int key="NSCellFlags2">134217728</int>
-													<string key="NSContents">Set Computer Name</string>
-													<reference key="NSSupport" ref="881900057"/>
-													<string key="NSCellIdentifier">_NS:9</string>
-													<reference key="NSControlView" ref="99115794"/>
-													<int key="NSButtonFlags">-2038284288</int>
-													<int key="NSButtonFlags2">129</int>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-											</object>
-										</array>
-										<string key="NSFrameSize">{680, 487}</string>
-										<reference key="NSNextKeyView" ref="857597622"/>
-										<string key="NSReuseIdentifierKey">_NS:28</string>
-									</object>
-									<string key="NSLabel">Main</string>
-									<reference key="NSColor" ref="607809683"/>
-									<reference key="NSTabView" ref="159778808"/>
-								</object>
-							</array>
-							<reference key="NSSelectedTabViewItem" ref="2383049"/>
-							<reference key="NSFont" ref="881900057"/>
-							<int key="NSTvFlags">6</int>
-							<bool key="NSAllowTruncatedLabels">YES</bool>
-							<array class="NSMutableArray" key="NSSubviews">
-								<reference ref="22249470"/>
-							</array>
-						</object>
-					</array>
-					<string key="NSFrameSize">{697, 503}</string>
-					<reference key="NSSuperview"/>
-					<reference key="NSWindow"/>
-					<reference key="NSNextKeyView" ref="461199512"/>
-					<bool key="NSViewIsLayerTreeHost">YES</bool>
-				</object>
-				<string key="NSScreenRect">{{0, 0}, {1280, 778}}</string>
-				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
-				<bool key="NSWindowIsRestorable">NO</bool>
-			</object>
-			<object class="NSWindowTemplate" id="1063748527">
-				<int key="NSWindowStyleMask">16</int>
-				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{120, 121}, {458, 86}}</string>
-				<int key="NSWTFlags">-1602747392</int>
-				<string key="NSWindowTitle">Window</string>
-				<string key="NSWindowClass">NSPanel</string>
-				<nil key="NSViewClass"/>
-				<nil key="NSUserInterfaceItemIdentifier"/>
-				<object class="NSView" key="NSWindowView" id="797659792">
-					<nil key="NSNextResponder"/>
-					<int key="NSvFlags">256</int>
-					<array class="NSMutableArray" key="NSSubviews">
-						<object class="NSTextField" id="615142721">
-							<reference key="NSNextResponder" ref="797659792"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{18, 49}, {422, 17}}</string>
-							<reference key="NSSuperview" ref="797659792"/>
-							<reference key="NSNextKeyView" ref="114446665"/>
-							<string key="NSHuggingPriority">{251, 750}</string>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="267191696">
-								<int key="NSCellFlags">68157504</int>
-								<int key="NSCellFlags2">272630784</int>
-								<string key="NSContents">Choose Startup Disk</string>
-								<reference key="NSSupport" ref="881900057"/>
-								<reference key="NSControlView" ref="615142721"/>
-								<reference key="NSBackgroundColor" ref="607809683"/>
-								<reference key="NSTextColor" ref="363351792"/>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-						</object>
-						<object class="NSPopUpButton" id="114446665">
-							<reference key="NSNextResponder" ref="797659792"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{18, 17}, {342, 26}}</string>
-							<reference key="NSSuperview" ref="797659792"/>
-							<reference key="NSNextKeyView" ref="541947500"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSPopUpButtonCell" key="NSCell" id="465124819">
-								<int key="NSCellFlags">-2076180416</int>
-								<int key="NSCellFlags2">2048</int>
-								<reference key="NSSupport" ref="641322834"/>
-								<reference key="NSControlView" ref="114446665"/>
-								<int key="NSButtonFlags">109199360</int>
-								<int key="NSButtonFlags2">129</int>
-								<reference key="NSAlternateImage" ref="378956934"/>
-								<string key="NSAlternateContents"/>
-								<string key="NSKeyEquivalent"/>
-								<int key="NSPeriodicDelay">400</int>
-								<int key="NSPeriodicInterval">75</int>
-								<object class="NSMenuItem" key="NSMenuItem" id="754473699">
-									<reference key="NSMenu" ref="576524088"/>
-									<string key="NSTitle">Startup Disk</string>
-									<string key="NSKeyEquiv"/>
-									<int key="NSKeyEquivModMask">1048576</int>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<int key="NSState">1</int>
-									<reference key="NSOnImage" ref="715147791"/>
-									<reference key="NSMixedImage" ref="897496305"/>
-									<string key="NSAction">_popUpItemAction:</string>
-									<reference key="NSTarget" ref="465124819"/>
-								</object>
-								<bool key="NSMenuItemRespectAlignment">YES</bool>
-								<object class="NSMenu" key="NSMenu" id="576524088">
-									<string key="NSTitle"/>
-									<array class="NSMutableArray" key="NSMenuItems">
-										<reference ref="754473699"/>
-										<object class="NSMenuItem" id="176280089">
-											<reference key="NSMenu" ref="576524088"/>
-											<string key="NSTitle">Item 2</string>
-											<string key="NSKeyEquiv"/>
-											<int key="NSKeyEquivModMask">1048576</int>
-											<int key="NSMnemonicLoc">2147483647</int>
-											<reference key="NSOnImage" ref="715147791"/>
-											<reference key="NSMixedImage" ref="897496305"/>
-											<string key="NSAction">_popUpItemAction:</string>
-											<reference key="NSTarget" ref="465124819"/>
-										</object>
-										<object class="NSMenuItem" id="428764403">
-											<reference key="NSMenu" ref="576524088"/>
-											<string key="NSTitle">Item 3</string>
-											<string key="NSKeyEquiv"/>
-											<int key="NSKeyEquivModMask">1048576</int>
-											<int key="NSMnemonicLoc">2147483647</int>
-											<reference key="NSOnImage" ref="715147791"/>
-											<reference key="NSMixedImage" ref="897496305"/>
-											<string key="NSAction">_popUpItemAction:</string>
-											<reference key="NSTarget" ref="465124819"/>
-										</object>
-									</array>
-								</object>
-								<int key="NSPreferredEdge">1</int>
-								<bool key="NSUsesItemFromMenu">YES</bool>
-								<bool key="NSAltersState">YES</bool>
-								<int key="NSArrowPosition">2</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="541947500">
-							<reference key="NSNextResponder" ref="797659792"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{359, 13}, {85, 32}}</string>
-							<reference key="NSSuperview" ref="797659792"/>
-							<string key="NSHuggingPriority">{250, 750}</string>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="380942625">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">134217728</int>
-								<string key="NSContents">Restart</string>
-								<reference key="NSSupport" ref="881900057"/>
-								<reference key="NSControlView" ref="541947500"/>
-								<int key="NSButtonFlags">-2038284288</int>
-								<int key="NSButtonFlags2">129</int>
-								<reference key="NSAlternateImage" ref="378956934"/>
-								<string key="NSAlternateContents"/>
-								<string type="base64-UTF8" key="NSKeyEquivalent">DQ</string>
-								<int key="NSPeriodicDelay">400</int>
-								<int key="NSPeriodicInterval">75</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-					</array>
-					<string key="NSFrameSize">{458, 86}</string>
-					<reference key="NSNextKeyView" ref="615142721"/>
-				</object>
-				<string key="NSScreenRect">{{0, 0}, {1280, 778}}</string>
-				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
-				<bool key="NSWindowIsRestorable">NO</bool>
-			</object>
-			<object class="NSWindowTemplate" id="1039104703">
-				<int key="NSWindowStyleMask">16</int>
-				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{120, 121}, {512, 96}}</string>
-				<int key="NSWTFlags">-1602747392</int>
-				<string key="NSWindowTitle">Window</string>
-				<string key="NSWindowClass">NSPanel</string>
-				<nil key="NSViewClass"/>
-				<nil key="NSUserInterfaceItemIdentifier"/>
-				<object class="NSView" key="NSWindowView" id="995259204">
-					<nil key="NSNextResponder"/>
-					<int key="NSvFlags">256</int>
-					<array class="NSMutableArray" key="NSSubviews">
-						<object class="NSButton" id="959641603">
-							<reference key="NSNextResponder" ref="995259204"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{369, 23}, {129, 32}}</string>
-							<reference key="NSSuperview" ref="995259204"/>
-							<string key="NSHuggingPriority">{250, 750}</string>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="601744127">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">134217728</int>
-								<string key="NSContents">Choose Target</string>
-								<reference key="NSSupport" ref="881900057"/>
-								<reference key="NSControlView" ref="959641603"/>
-								<int key="NSButtonFlags">-2038284288</int>
-								<int key="NSButtonFlags2">129</int>
-								<reference key="NSAlternateImage" ref="378956934"/>
-								<string key="NSAlternateContents"/>
-								<string type="base64-UTF8" key="NSKeyEquivalent">DQ</string>
-								<int key="NSPeriodicDelay">400</int>
-								<int key="NSPeriodicInterval">75</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="1049495274">
-							<reference key="NSNextResponder" ref="995259204"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{287, 23}, {83, 32}}</string>
-							<reference key="NSSuperview" ref="995259204"/>
-							<reference key="NSNextKeyView" ref="959641603"/>
-							<string key="NSHuggingPriority">{250, 750}</string>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="119799730">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">134217728</int>
-								<string key="NSContents">Cancel</string>
-								<reference key="NSSupport" ref="881900057"/>
-								<reference key="NSControlView" ref="1049495274"/>
-								<int key="NSButtonFlags">-2038284288</int>
-								<int key="NSButtonFlags2">129</int>
-								<reference key="NSAlternateImage" ref="378956934"/>
-								<string key="NSAlternateContents"/>
-								<string type="base64-UTF8" key="NSKeyEquivalent">Gw</string>
-								<int key="NSPeriodicDelay">400</int>
-								<int key="NSPeriodicInterval">75</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSTextField" id="253896453">
-							<reference key="NSNextResponder" ref="995259204"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{18, 54}, {95, 17}}</string>
-							<reference key="NSSuperview" ref="995259204"/>
-							<reference key="NSNextKeyView" ref="1049495274"/>
-							<string key="NSReuseIdentifierKey">_NS:526</string>
-							<string key="NSHuggingPriority">{251, 750}</string>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="87137286">
-								<int key="NSCellFlags">68157504</int>
-								<int key="NSCellFlags2">272630784</int>
-								<string key="NSContents">Choose Target</string>
-								<reference key="NSSupport" ref="881900057"/>
-								<string key="NSCellIdentifier">_NS:526</string>
-								<reference key="NSControlView" ref="253896453"/>
-								<reference key="NSBackgroundColor" ref="607809683"/>
-								<reference key="NSTextColor" ref="499429957"/>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-						</object>
-					</array>
-					<string key="NSFrameSize">{512, 96}</string>
-					<reference key="NSNextKeyView" ref="253896453"/>
-				</object>
-				<string key="NSScreenRect">{{0, 0}, {1280, 778}}</string>
-				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
-				<bool key="NSWindowIsRestorable">NO</bool>
-			</object>
-			<object class="NSWindowTemplate" id="415152891">
-				<int key="NSWindowStyleMask">17</int>
-				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{139, 81}, {466, 98}}</string>
-				<int key="NSWTFlags">-1602747392</int>
-				<string key="NSWindowTitle">Window</string>
-				<string key="NSWindowClass">NSPanel</string>
-				<nil key="NSViewClass"/>
-				<nil key="NSUserInterfaceItemIdentifier"/>
-				<object class="NSView" key="NSWindowView" id="976016814">
-					<nil key="NSNextResponder"/>
-					<int key="NSvFlags">256</int>
-					<array class="NSMutableArray" key="NSSubviews">
-						<object class="NSProgressIndicator" id="344777478">
-							<reference key="NSNextResponder" ref="976016814"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{20, 39}, {426, 20}}</string>
-							<reference key="NSSuperview" ref="976016814"/>
-							<reference key="NSNextKeyView" ref="893580892"/>
-							<string key="NSHuggingPriority">{250, 250}</string>
-							<int key="NSpiFlags">16399</int>
-							<double key="NSMaxValue">100</double>
-						</object>
-						<object class="NSTextField" id="29244736">
-							<reference key="NSNextResponder" ref="976016814"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{17, 66}, {431, 17}}</string>
-							<reference key="NSSuperview" ref="976016814"/>
-							<reference key="NSNextKeyView" ref="344777478"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="743351425">
-								<int key="NSCellFlags">68157504</int>
-								<int key="NSCellFlags2">272630784</int>
-								<string key="NSContents">Imaging progress label</string>
-								<reference key="NSSupport" ref="881900057"/>
-								<reference key="NSControlView" ref="29244736"/>
-								<reference key="NSBackgroundColor" ref="607809683"/>
-								<reference key="NSTextColor" ref="499429957"/>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-						</object>
-						<object class="NSTextField" id="893580892">
-							<reference key="NSNextResponder" ref="976016814"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{18, 20}, {431, 17}}</string>
-							<reference key="NSSuperview" ref="976016814"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="186590015">
-								<int key="NSCellFlags">68157504</int>
-								<int key="NSCellFlags2">272630784</int>
-								<string key="NSContents">Imaging progress detail</string>
-								<object class="NSFont" key="NSSupport">
-									<bool key="IBIsSystemFont">YES</bool>
-									<double key="NSSize">11</double>
-									<int key="NSfFlags">3100</int>
-								</object>
-								<reference key="NSControlView" ref="893580892"/>
-								<reference key="NSBackgroundColor" ref="607809683"/>
-								<reference key="NSTextColor" ref="499429957"/>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-						</object>
-					</array>
-					<string key="NSFrameSize">{466, 98}</string>
-					<reference key="NSNextKeyView" ref="29244736"/>
-				</object>
-				<string key="NSScreenRect">{{0, 0}, {1280, 778}}</string>
-				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
-				<bool key="NSWindowIsRestorable">NO</bool>
-			</object>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array key="connectionRecords">
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="1050"/>
-						<reference key="destination" ref="610635028"/>
-					</object>
-					<int key="connectionID">374</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">orderFrontStandardAboutPanel:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="238522557"/>
-					</object>
-					<int key="connectionID">142</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">hide:</string>
-						<reference key="source" ref="1014"/>
-						<reference key="destination" ref="755159360"/>
-					</object>
-					<int key="connectionID">367</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">hideOtherApplications:</string>
-						<reference key="source" ref="1014"/>
-						<reference key="destination" ref="342932134"/>
-					</object>
-					<int key="connectionID">368</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">terminate:</string>
-						<reference key="source" ref="1014"/>
-						<reference key="destination" ref="632727374"/>
-					</object>
-					<int key="connectionID">369</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">unhideAllApplications:</string>
-						<reference key="source" ref="1014"/>
-						<reference key="destination" ref="908899353"/>
-					</object>
-					<int key="connectionID">370</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">mainController</string>
-						<reference key="source" ref="610635028"/>
-						<reference key="destination" ref="1061118799"/>
-					</object>
-					<int key="connectionID">816</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">startupDiskDropdown</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="114446665"/>
-					</object>
-					<int key="connectionID">692</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">startUpDiskPanel</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="1063748527"/>
-					</object>
-					<int key="connectionID">693</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">startupDiskRestartButton</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="541947500"/>
-					</object>
-					<int key="connectionID">694</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">startUpDiskText</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="615142721"/>
-					</object>
-					<int key="connectionID">695</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">mainWindow</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="125443915"/>
-					</object>
-					<int key="connectionID">697</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">chooseTargetCancelButton</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="1049495274"/>
-					</object>
-					<int key="connectionID">718</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">chooseTargetPanel</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="1039104703"/>
-					</object>
-					<int key="connectionID">720</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">chooseTargetPanelSelectTarget</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="959641603"/>
-					</object>
-					<int key="connectionID">721</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">closeImagingTarget:</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="1049495274"/>
-					</object>
-					<int key="connectionID">722</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">imagingProgressPanel</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="415152891"/>
-					</object>
-					<int key="connectionID">798</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">imagingLabel</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="29244736"/>
-					</object>
-					<int key="connectionID">799</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">imagingProgress</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="344777478"/>
-					</object>
-					<int key="connectionID">800</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">imagingProgressDetail</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="893580892"/>
-					</object>
-					<int key="connectionID">803</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">loginLabel</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="955668471"/>
-					</object>
-					<int key="connectionID">667</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">password</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="567205958"/>
-					</object>
-					<int key="connectionID">671</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">login:</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="567205958"/>
-					</object>
-					<int key="connectionID">679</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">loginButton</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="70639366"/>
-					</object>
-					<int key="connectionID">666</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">login:</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="70639366"/>
-					</object>
-					<int key="connectionID">678</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">errorField</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="705431801"/>
-					</object>
-					<int key="connectionID">665</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">chooseWorkflowDropDownDidChange:</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="72689598"/>
-					</object>
-					<int key="connectionID">771</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">chooseWorkflowDropDown</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="72689598"/>
-					</object>
-					<int key="connectionID">756</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">setStartupDisk:</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="300259507"/>
-					</object>
-					<int key="connectionID">696</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">cancelAndRestartButton</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="300259507"/>
-					</object>
-					<int key="connectionID">724</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">chooseWorkflowLabel</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="300259507"/>
-					</object>
-					<int key="connectionID">757</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">workflowDescription</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="54294484"/>
-					</object>
-					<int key="connectionID">773</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">workflowDescriptionView</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="37250636"/>
-					</object>
-					<int key="connectionID">772</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">runWorkflow:</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="1035765763"/>
-					</object>
-					<int key="connectionID">778</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">runWorkflowButton</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="1035765763"/>
-					</object>
-					<int key="connectionID">779</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">progressIndicator</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="958872179"/>
-					</object>
-					<int key="connectionID">839</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">progressText</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="134608693"/>
-					</object>
-					<int key="connectionID">840</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">theTabView</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="159778808"/>
-					</object>
-					<int key="connectionID">841</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">loginTab</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="632038340"/>
-					</object>
-					<int key="connectionID">842</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">mainTab</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="2383049"/>
-					</object>
-					<int key="connectionID">843</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">introTab</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="671669968"/>
-					</object>
-					<int key="connectionID">864</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">errorTab</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="760072728"/>
-					</object>
-					<int key="connectionID">885</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">restartButtonClicked:</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="541947500"/>
-					</object>
-					<int key="connectionID">888</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">utilities_menu</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="348727561"/>
-					</object>
-					<int key="connectionID">908</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">reloadWorkflowsButton</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="139496358"/>
-					</object>
-					<int key="connectionID">912</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">reloadWorkflows:</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="139496358"/>
-					</object>
-					<int key="connectionID">913</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">reloadWorkflowsMenuItem</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="262723819"/>
-					</object>
-					<int key="connectionID">918</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">reloadWorkflows:</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="262723819"/>
-					</object>
-					<int key="connectionID">919</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">chooseTargetDropDown</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="555067212"/>
-					</object>
-					<int key="connectionID">719</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">selectImagingTarget:</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="555067212"/>
-					</object>
-					<int key="connectionID">941</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">computerNameInput</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="238691935"/>
-					</object>
-					<int key="connectionID">960</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">computerNameButton</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="99115794"/>
-					</object>
-					<int key="connectionID">961</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">computerNameTab</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="293211172"/>
-					</object>
-					<int key="connectionID">962</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">setComputerName:</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="1003346449"/>
-					</object>
-					<int key="connectionID">967</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">showHelp:</string>
-						<reference key="source" ref="1061118799"/>
-						<reference key="destination" ref="238773614"/>
-					</object>
-					<int key="connectionID">974</int>
-				</object>
-			</array>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<array key="object" id="0"/>
-						<reference key="children" ref="1048"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="1021"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="1014"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">First Responder</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-3</int>
-						<reference key="object" ref="1050"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Application</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">29</int>
-						<reference key="object" ref="649796088"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="391199113"/>
-							<reference ref="694149608"/>
-							<reference ref="210252055"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">MainMenu</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">56</int>
-						<reference key="object" ref="694149608"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="110575045"/>
-						</array>
-						<reference key="parent" ref="649796088"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">103</int>
-						<reference key="object" ref="391199113"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="374024848"/>
-						</array>
-						<reference key="parent" ref="649796088"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">106</int>
-						<reference key="object" ref="374024848"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="238773614"/>
-						</array>
-						<reference key="parent" ref="391199113"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">111</int>
-						<reference key="object" ref="238773614"/>
-						<reference key="parent" ref="374024848"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">57</int>
-						<reference key="object" ref="110575045"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="238522557"/>
-							<reference ref="755159360"/>
-							<reference ref="908899353"/>
-							<reference ref="632727374"/>
-							<reference ref="646227648"/>
-							<reference ref="481834944"/>
-							<reference ref="1046388886"/>
-							<reference ref="1056857174"/>
-							<reference ref="342932134"/>
-							<reference ref="262723819"/>
-							<reference ref="329851051"/>
-						</array>
-						<reference key="parent" ref="694149608"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">58</int>
-						<reference key="object" ref="238522557"/>
-						<reference key="parent" ref="110575045"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">134</int>
-						<reference key="object" ref="755159360"/>
-						<reference key="parent" ref="110575045"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">150</int>
-						<reference key="object" ref="908899353"/>
-						<reference key="parent" ref="110575045"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">136</int>
-						<reference key="object" ref="632727374"/>
-						<reference key="parent" ref="110575045"/>
-						<string key="objectName">1111</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">144</int>
-						<reference key="object" ref="646227648"/>
-						<reference key="parent" ref="110575045"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">143</int>
-						<reference key="object" ref="481834944"/>
-						<reference key="parent" ref="110575045"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">131</int>
-						<reference key="object" ref="1046388886"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="752062318"/>
-						</array>
-						<reference key="parent" ref="110575045"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">149</int>
-						<reference key="object" ref="1056857174"/>
-						<reference key="parent" ref="110575045"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">145</int>
-						<reference key="object" ref="342932134"/>
-						<reference key="parent" ref="110575045"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">130</int>
-						<reference key="object" ref="752062318"/>
-						<reference key="parent" ref="1046388886"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">373</int>
-						<reference key="object" ref="610635028"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">AppDelegate</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">420</int>
-						<reference key="object" ref="15635064"/>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">450</int>
-						<reference key="object" ref="125443915"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="367560152"/>
-						</array>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">452</int>
-						<reference key="object" ref="1063748527"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="797659792"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Restart</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">453</int>
-						<reference key="object" ref="797659792"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="114446665"/>
-							<reference ref="615142721"/>
-							<reference ref="541947500"/>
-						</array>
-						<reference key="parent" ref="1063748527"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">455</int>
-						<reference key="object" ref="541947500"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="380942625"/>
-						</array>
-						<reference key="parent" ref="797659792"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">456</int>
-						<reference key="object" ref="114446665"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="465124819"/>
-						</array>
-						<reference key="parent" ref="797659792"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">457</int>
-						<reference key="object" ref="615142721"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="267191696"/>
-						</array>
-						<reference key="parent" ref="797659792"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">458</int>
-						<reference key="object" ref="267191696"/>
-						<reference key="parent" ref="615142721"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">459</int>
-						<reference key="object" ref="465124819"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="576524088"/>
-						</array>
-						<reference key="parent" ref="114446665"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">460</int>
-						<reference key="object" ref="576524088"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="428764403"/>
-							<reference ref="176280089"/>
-							<reference ref="754473699"/>
-						</array>
-						<reference key="parent" ref="465124819"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">461</int>
-						<reference key="object" ref="428764403"/>
-						<reference key="parent" ref="576524088"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">462</int>
-						<reference key="object" ref="176280089"/>
-						<reference key="parent" ref="576524088"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">463</int>
-						<reference key="object" ref="754473699"/>
-						<reference key="parent" ref="576524088"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">464</int>
-						<reference key="object" ref="380942625"/>
-						<reference key="parent" ref="541947500"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">470</int>
-						<reference key="object" ref="367560152"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="461199512"/>
-							<reference ref="159778808"/>
-						</array>
-						<reference key="parent" ref="125443915"/>
-						<string key="objectName">Container</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">664</int>
-						<reference key="object" ref="1061118799"/>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">703</int>
-						<reference key="object" ref="1039104703"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="995259204"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Choose Target</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">704</int>
-						<reference key="object" ref="995259204"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="959641603"/>
-							<reference ref="1049495274"/>
-							<reference ref="253896453"/>
-						</array>
-						<reference key="parent" ref="1039104703"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">707</int>
-						<reference key="object" ref="959641603"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="601744127"/>
-						</array>
-						<reference key="parent" ref="995259204"/>
-						<string key="objectName">Choose Target</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">708</int>
-						<reference key="object" ref="1049495274"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="119799730"/>
-						</array>
-						<reference key="parent" ref="995259204"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">709</int>
-						<reference key="object" ref="119799730"/>
-						<reference key="parent" ref="1049495274"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">710</int>
-						<reference key="object" ref="601744127"/>
-						<reference key="parent" ref="959641603"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">791</int>
-						<reference key="object" ref="415152891"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="976016814"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Imaging Progress</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">792</int>
-						<reference key="object" ref="976016814"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="344777478"/>
-							<reference ref="29244736"/>
-							<reference ref="893580892"/>
-						</array>
-						<reference key="parent" ref="415152891"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">793</int>
-						<reference key="object" ref="344777478"/>
-						<reference key="parent" ref="976016814"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">801</int>
-						<reference key="object" ref="893580892"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="186590015"/>
-						</array>
-						<reference key="parent" ref="976016814"/>
-						<string key="objectName">Imaging Progress Label</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">802</int>
-						<reference key="object" ref="186590015"/>
-						<reference key="parent" ref="893580892"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">471</int>
-						<reference key="object" ref="461199512"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="283991686"/>
-						</array>
-						<reference key="parent" ref="367560152"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">484</int>
-						<reference key="object" ref="283991686"/>
-						<reference key="parent" ref="461199512"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">829</int>
-						<reference key="object" ref="159778808"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="2383049"/>
-							<reference ref="632038340"/>
-							<reference ref="671669968"/>
-							<reference ref="760072728"/>
-							<reference ref="293211172"/>
-						</array>
-						<reference key="parent" ref="367560152"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">830</int>
-						<reference key="object" ref="2383049"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="22249470"/>
-						</array>
-						<reference key="parent" ref="159778808"/>
-						<string key="objectName">Main</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">831</int>
-						<reference key="object" ref="632038340"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="482842367"/>
-						</array>
-						<reference key="parent" ref="159778808"/>
-						<string key="objectName">Login</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">832</int>
-						<reference key="object" ref="482842367"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="567205958"/>
-							<reference ref="70639366"/>
-							<reference ref="955668471"/>
-							<reference ref="705431801"/>
-						</array>
-						<reference key="parent" ref="632038340"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">833</int>
-						<reference key="object" ref="22249470"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="37250636"/>
-							<reference ref="300259507"/>
-							<reference ref="1035765763"/>
-							<reference ref="555067212"/>
-							<reference ref="127573865"/>
-							<reference ref="72689598"/>
-							<reference ref="614889614"/>
-							<reference ref="139496358"/>
-						</array>
-						<reference key="parent" ref="2383049"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">479</int>
-						<reference key="object" ref="955668471"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="500681499"/>
-						</array>
-						<reference key="parent" ref="482842367"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">480</int>
-						<reference key="object" ref="500681499"/>
-						<reference key="parent" ref="955668471"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">478</int>
-						<reference key="object" ref="567205958"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="755388124"/>
-						</array>
-						<reference key="parent" ref="482842367"/>
-						<string key="objectName">Password</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">481</int>
-						<reference key="object" ref="755388124"/>
-						<reference key="parent" ref="567205958"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">477</int>
-						<reference key="object" ref="70639366"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1048853569"/>
-						</array>
-						<reference key="parent" ref="482842367"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">482</int>
-						<reference key="object" ref="1048853569"/>
-						<reference key="parent" ref="70639366"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">476</int>
-						<reference key="object" ref="705431801"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="942098964"/>
-						</array>
-						<reference key="parent" ref="482842367"/>
-						<string key="objectName">Error</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">483</int>
-						<reference key="object" ref="942098964"/>
-						<reference key="parent" ref="705431801"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">748</int>
-						<reference key="object" ref="72689598"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="67273808"/>
-						</array>
-						<reference key="parent" ref="22249470"/>
-						<string key="objectName">WorkflowPulldown</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">749</int>
-						<reference key="object" ref="67273808"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1046540592"/>
-						</array>
-						<reference key="parent" ref="72689598"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">750</int>
-						<reference key="object" ref="1046540592"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="254823087"/>
-							<reference ref="547346547"/>
-							<reference ref="332266605"/>
-						</array>
-						<reference key="parent" ref="67273808"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">753</int>
-						<reference key="object" ref="254823087"/>
-						<reference key="parent" ref="1046540592"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">752</int>
-						<reference key="object" ref="547346547"/>
-						<reference key="parent" ref="1046540592"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">751</int>
-						<reference key="object" ref="332266605"/>
-						<reference key="parent" ref="1046540592"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">474</int>
-						<reference key="object" ref="300259507"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="389625284"/>
-						</array>
-						<reference key="parent" ref="22249470"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">475</int>
-						<reference key="object" ref="389625284"/>
-						<reference key="parent" ref="300259507"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">761</int>
-						<reference key="object" ref="37250636"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="54294484"/>
-							<reference ref="723861177"/>
-							<reference ref="375661957"/>
-						</array>
-						<reference key="parent" ref="22249470"/>
-						<string key="objectName">Workflow Description</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">762</int>
-						<reference key="object" ref="54294484"/>
-						<reference key="parent" ref="37250636"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">763</int>
-						<reference key="object" ref="723861177"/>
-						<reference key="parent" ref="37250636"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">764</int>
-						<reference key="object" ref="375661957"/>
-						<reference key="parent" ref="37250636"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">774</int>
-						<reference key="object" ref="1035765763"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="837689253"/>
-						</array>
-						<reference key="parent" ref="22249470"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">775</int>
-						<reference key="object" ref="837689253"/>
-						<reference key="parent" ref="1035765763"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">834</int>
-						<reference key="object" ref="671669968"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="366981630"/>
-						</array>
-						<reference key="parent" ref="159778808"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">835</int>
-						<reference key="object" ref="366981630"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="958872179"/>
-							<reference ref="134608693"/>
-						</array>
-						<reference key="parent" ref="671669968"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">836</int>
-						<reference key="object" ref="958872179"/>
-						<reference key="parent" ref="366981630"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">837</int>
-						<reference key="object" ref="134608693"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="982909434"/>
-						</array>
-						<reference key="parent" ref="366981630"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">838</int>
-						<reference key="object" ref="982909434"/>
-						<reference key="parent" ref="134608693"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">866</int>
-						<reference key="object" ref="760072728"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="344944858"/>
-						</array>
-						<reference key="parent" ref="159778808"/>
-						<string key="objectName">Error</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">867</int>
-						<reference key="object" ref="344944858"/>
-						<array class="NSMutableArray" key="children"/>
-						<reference key="parent" ref="760072728"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">794</int>
-						<reference key="object" ref="29244736"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="743351425"/>
-						</array>
-						<reference key="parent" ref="976016814"/>
-						<string key="objectName">Imaging Progress Label</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">795</int>
-						<reference key="object" ref="743351425"/>
-						<reference key="parent" ref="29244736"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">898</int>
-						<reference key="object" ref="210252055"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="348727561"/>
-						</array>
-						<reference key="parent" ref="649796088"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">899</int>
-						<reference key="object" ref="348727561"/>
-						<array class="NSMutableArray" key="children"/>
-						<reference key="parent" ref="210252055"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">909</int>
-						<reference key="object" ref="139496358"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="164015895"/>
-						</array>
-						<reference key="parent" ref="22249470"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">910</int>
-						<reference key="object" ref="164015895"/>
-						<reference key="parent" ref="139496358"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">914</int>
-						<reference key="object" ref="262723819"/>
-						<reference key="parent" ref="110575045"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">917</int>
-						<reference key="object" ref="329851051"/>
-						<reference key="parent" ref="110575045"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">706</int>
-						<reference key="object" ref="555067212"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="862068476"/>
-						</array>
-						<reference key="parent" ref="22249470"/>
-						<string key="objectName">Target</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">711</int>
-						<reference key="object" ref="862068476"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="374469571"/>
-						</array>
-						<reference key="parent" ref="555067212"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">712</int>
-						<reference key="object" ref="374469571"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="509731998"/>
-							<reference ref="1016311381"/>
-							<reference ref="697511182"/>
-						</array>
-						<reference key="parent" ref="862068476"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">715</int>
-						<reference key="object" ref="509731998"/>
-						<reference key="parent" ref="374469571"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">714</int>
-						<reference key="object" ref="1016311381"/>
-						<reference key="parent" ref="374469571"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">713</int>
-						<reference key="object" ref="697511182"/>
-						<reference key="parent" ref="374469571"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">936</int>
-						<reference key="object" ref="127573865"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="481495187"/>
-						</array>
-						<reference key="parent" ref="22249470"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">937</int>
-						<reference key="object" ref="481495187"/>
-						<reference key="parent" ref="127573865"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">938</int>
-						<reference key="object" ref="614889614"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="365765916"/>
-						</array>
-						<reference key="parent" ref="22249470"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">939</int>
-						<reference key="object" ref="365765916"/>
-						<reference key="parent" ref="614889614"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">942</int>
-						<reference key="object" ref="293211172"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="50591286"/>
-						</array>
-						<reference key="parent" ref="159778808"/>
-						<string key="objectName">Computer Name</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">943</int>
-						<reference key="object" ref="50591286"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="238691935"/>
-							<reference ref="857597622"/>
-							<reference ref="99115794"/>
-						</array>
-						<reference key="parent" ref="293211172"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">946</int>
-						<reference key="object" ref="857597622"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="324106665"/>
-						</array>
-						<reference key="parent" ref="50591286"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">947</int>
-						<reference key="object" ref="324106665"/>
-						<reference key="parent" ref="857597622"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">954</int>
-						<reference key="object" ref="238691935"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="744391400"/>
-						</array>
-						<reference key="parent" ref="50591286"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">955</int>
-						<reference key="object" ref="744391400"/>
-						<reference key="parent" ref="238691935"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">956</int>
-						<reference key="object" ref="99115794"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1003346449"/>
-						</array>
-						<reference key="parent" ref="50591286"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">957</int>
-						<reference key="object" ref="1003346449"/>
-						<reference key="parent" ref="99115794"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">968</int>
-						<reference key="object" ref="253896453"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="87137286"/>
-						</array>
-						<reference key="parent" ref="995259204"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">969</int>
-						<reference key="object" ref="87137286"/>
-						<reference key="parent" ref="253896453"/>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-3.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="103.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="106.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="111.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="130.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="131.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="134.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="136.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="143.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="144.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="145.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="149.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="150.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="29.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="373.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="420.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="450.IBNSWindowAutoPositionCentersHorizontal"/>
-				<boolean value="YES" key="450.IBNSWindowAutoPositionCentersVertical"/>
-				<string key="450.IBPersistedLastKnownCanvasPosition">{36.5, 6.5}</string>
-				<string key="450.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="450.NSWindowTemplate.visibleAtLaunch"/>
-				<boolean value="NO" key="452.IBNSWindowAutoPositionCentersHorizontal"/>
-				<boolean value="NO" key="452.IBNSWindowAutoPositionCentersVertical"/>
-				<string key="452.IBPersistedLastKnownCanvasPosition">{-178, 596}</string>
-				<string key="452.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="453.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="453.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="453.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="453.IBUserGuides" ref="0"/>
-				<boolean value="NO" key="455.IBNSControlSetsMaxLayoutWidthAtFirstLayoutMetadataKey"/>
-				<reference key="455.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="455.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="455.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="455.IBUserGuides" ref="0"/>
-				<boolean value="NO" key="456.IBNSControlSetsMaxLayoutWidthAtFirstLayoutMetadataKey"/>
-				<reference key="456.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="456.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="456.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="456.IBUserGuides" ref="0"/>
-				<boolean value="NO" key="457.IBNSControlSetsMaxLayoutWidthAtFirstLayoutMetadataKey"/>
-				<reference key="457.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="457.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="457.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="457.IBUserGuides" ref="0"/>
-				<string key="458.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="459.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="460.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="461.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="462.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="463.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="464.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="470.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="470.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="470.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="470.IBUserGuides" ref="0"/>
-				<boolean value="NO" key="471.IBNSControlSetsMaxLayoutWidthAtFirstLayoutMetadataKey"/>
-				<reference key="471.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="471.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="471.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="471.IBUserGuides" ref="0"/>
-				<boolean value="NO" key="474.IBNSControlSetsMaxLayoutWidthAtFirstLayoutMetadataKey"/>
-				<reference key="474.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="474.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="474.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="474.IBUserGuides" ref="0"/>
-				<string key="475.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="NO" key="476.IBNSControlSetsMaxLayoutWidthAtFirstLayoutMetadataKey"/>
-				<reference key="476.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="476.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="476.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="476.IBUserGuides" ref="0"/>
-				<boolean value="NO" key="477.IBNSControlSetsMaxLayoutWidthAtFirstLayoutMetadataKey"/>
-				<reference key="477.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="477.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="477.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="477.IBUserGuides" ref="0"/>
-				<boolean value="NO" key="478.IBNSControlSetsMaxLayoutWidthAtFirstLayoutMetadataKey"/>
-				<reference key="478.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="478.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="478.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="478.IBUserGuides" ref="0"/>
-				<boolean value="NO" key="479.IBNSControlSetsMaxLayoutWidthAtFirstLayoutMetadataKey"/>
-				<reference key="479.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="479.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="479.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="479.IBUserGuides" ref="0"/>
-				<string key="480.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="481.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="482.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="483.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="484.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="56.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="57.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="58.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="664.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="NO" key="703.IBNSWindowAutoPositionCentersHorizontal"/>
-				<boolean value="NO" key="703.IBNSWindowAutoPositionCentersVertical"/>
-				<string key="703.IBPersistedLastKnownCanvasPosition">{442, 412}</string>
-				<string key="703.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="704.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="704.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="704.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="704.IBUserGuides" ref="0"/>
-				<boolean value="NO" key="706.IBNSControlSetsMaxLayoutWidthAtFirstLayoutMetadataKey"/>
-				<reference key="706.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="706.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="706.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="706.IBUserGuides" ref="0"/>
-				<boolean value="NO" key="707.IBNSControlSetsMaxLayoutWidthAtFirstLayoutMetadataKey"/>
-				<reference key="707.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="707.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="707.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="707.IBUserGuides" ref="0"/>
-				<boolean value="NO" key="708.IBNSControlSetsMaxLayoutWidthAtFirstLayoutMetadataKey"/>
-				<reference key="708.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="708.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="708.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="708.IBUserGuides" ref="0"/>
-				<string key="709.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="710.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="711.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="712.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="713.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="714.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="715.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="748.IBPersistedLastKnownCanvasPosition">{319.5, 232.5}</string>
-				<string key="748.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="749.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="750.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="751.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="752.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="753.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="761.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="762.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="763.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="764.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="774.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="775.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="NO" key="791.IBNSWindowAutoPositionCentersHorizontal"/>
-				<boolean value="NO" key="791.IBNSWindowAutoPositionCentersVertical"/>
-				<string key="791.IBPersistedLastKnownCanvasPosition">{-160, 406}</string>
-				<string key="791.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="792.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="792.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="792.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="792.IBUserGuides" ref="0"/>
-				<reference key="793.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="793.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="793.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="793.IBUserGuides" ref="0"/>
-				<boolean value="NO" key="794.IBNSControlSetsMaxLayoutWidthAtFirstLayoutMetadataKey"/>
-				<reference key="794.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="794.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="794.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="794.IBUserGuides" ref="0"/>
-				<string key="795.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="NO" key="801.IBNSControlSetsMaxLayoutWidthAtFirstLayoutMetadataKey"/>
-				<reference key="801.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="801.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="801.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="801.IBUserGuides" ref="0"/>
-				<string key="802.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="829.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">InitialTabViewItem</string>
-					<object class="IBInitialTabViewItemAttribute" key="NS.object.0">
-						<string key="name">InitialTabViewItem</string>
-						<reference key="object" ref="159778808"/>
-						<reference key="initialTabViewItem" ref="671669968"/>
-					</object>
-				</object>
-				<reference key="829.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="829.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="830.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="831.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="832.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="832.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="833.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="833.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="834.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="835.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="835.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="836.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="837.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="838.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="866.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="867.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="867.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="898.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="899.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="NO" key="909.IBNSControlSetsMaxLayoutWidthAtFirstLayoutMetadataKey"/>
-				<reference key="909.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="909.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="909.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="909.IBUserGuides" ref="0"/>
-				<string key="910.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="914.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="917.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="NO" key="936.IBNSControlSetsMaxLayoutWidthAtFirstLayoutMetadataKey"/>
-				<reference key="936.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="936.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="936.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="936.IBUserGuides" ref="0"/>
-				<string key="937.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="NO" key="938.IBNSControlSetsMaxLayoutWidthAtFirstLayoutMetadataKey"/>
-				<reference key="938.IBNSViewMetadataConstraints" ref="0"/>
-				<reference key="938.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="938.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="938.IBUserGuides" ref="0"/>
-				<string key="939.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="942.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="943.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="943.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="946.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="947.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="954.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="955.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="956.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="957.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="968.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="969.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-			<int key="maxID">974</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">AppDelegate</string>
-					<string key="superclassName">NSObject</string>
-					<object class="NSMutableDictionary" key="outlets">
-						<string key="NS.key.0">mainController</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<string key="NS.key.0">mainController</string>
-						<object class="IBToOneOutletInfo" key="NS.object.0">
-							<string key="name">mainController</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../Imagr/AppDelegate.py</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">MainController</string>
-					<string key="superclassName">NSObject</string>
-					<dictionary class="NSMutableDictionary" key="actions">
-						<string key="chooseImagingTarget:">id</string>
-						<string key="chooseWorkflowDropDownDidChange:">id</string>
-						<string key="closeImagingTarget:">id</string>
-						<string key="closeStartUpDisk:">id</string>
-						<string key="login:">id</string>
-						<string key="openProgress:">id</string>
-						<string key="reloadWorkflows:">id</string>
-						<string key="restartButtonClicked:">id</string>
-						<string key="runUtilityFromMenu:">id</string>
-						<string key="runWorkflow:">id</string>
-						<string key="selectImagingTarget:">id</string>
-						<string key="selectWorkflow:">id</string>
-						<string key="setComputerName:">id</string>
-						<string key="setStartupDisk:">id</string>
-						<string key="showHelp:">id</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="actionInfosByName">
-						<object class="IBActionInfo" key="chooseImagingTarget:">
-							<string key="name">chooseImagingTarget:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="chooseWorkflowDropDownDidChange:">
-							<string key="name">chooseWorkflowDropDownDidChange:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="closeImagingTarget:">
-							<string key="name">closeImagingTarget:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="closeStartUpDisk:">
-							<string key="name">closeStartUpDisk:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="login:">
-							<string key="name">login:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="openProgress:">
-							<string key="name">openProgress:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="reloadWorkflows:">
-							<string key="name">reloadWorkflows:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="restartButtonClicked:">
-							<string key="name">restartButtonClicked:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="runUtilityFromMenu:">
-							<string key="name">runUtilityFromMenu:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="runWorkflow:">
-							<string key="name">runWorkflow:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="selectImagingTarget:">
-							<string key="name">selectImagingTarget:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="selectWorkflow:">
-							<string key="name">selectWorkflow:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="setComputerName:">
-							<string key="name">setComputerName:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="setStartupDisk:">
-							<string key="name">setStartupDisk:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="showHelp:">
-							<string key="name">showHelp:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="outlets">
-						<string key="cancelAndRestartButton">id</string>
-						<string key="chooseTargetCancelButton">id</string>
-						<string key="chooseTargetDropDown">id</string>
-						<string key="chooseTargetPanel">id</string>
-						<string key="chooseTargetPanelSelectTarget">id</string>
-						<string key="chooseWorkflowDropDown">id</string>
-						<string key="chooseWorkflowLabel">id</string>
-						<string key="computerNameButton">id</string>
-						<string key="computerNameInput">id</string>
-						<string key="computerNameTab">id</string>
-						<string key="errorField">id</string>
-						<string key="errorTab">id</string>
-						<string key="help_menu">id</string>
-						<string key="imagingLabel">id</string>
-						<string key="imagingProgress">id</string>
-						<string key="imagingProgressDetail">id</string>
-						<string key="imagingProgressPanel">id</string>
-						<string key="introTab">id</string>
-						<string key="loginButton">id</string>
-						<string key="loginLabel">id</string>
-						<string key="loginTab">id</string>
-						<string key="mainTab">id</string>
-						<string key="mainWindow">id</string>
-						<string key="password">id</string>
-						<string key="passwordLabel">id</string>
-						<string key="progressIndicator">id</string>
-						<string key="progressText">id</string>
-						<string key="reloadWorkflowsButton">id</string>
-						<string key="reloadWorkflowsMenuItem">id</string>
-						<string key="runWorkflowButton">id</string>
-						<string key="startUpDiskPanel">id</string>
-						<string key="startUpDiskText">id</string>
-						<string key="startupDiskCancelButton">id</string>
-						<string key="startupDiskDropdown">id</string>
-						<string key="startupDiskRestartButton">id</string>
-						<string key="theTabView">id</string>
-						<string key="utilities_menu">id</string>
-						<string key="workflowDescription">id</string>
-						<string key="workflowDescriptionView">id</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<object class="IBToOneOutletInfo" key="cancelAndRestartButton">
-							<string key="name">cancelAndRestartButton</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="chooseTargetCancelButton">
-							<string key="name">chooseTargetCancelButton</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="chooseTargetDropDown">
-							<string key="name">chooseTargetDropDown</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="chooseTargetPanel">
-							<string key="name">chooseTargetPanel</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="chooseTargetPanelSelectTarget">
-							<string key="name">chooseTargetPanelSelectTarget</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="chooseWorkflowDropDown">
-							<string key="name">chooseWorkflowDropDown</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="chooseWorkflowLabel">
-							<string key="name">chooseWorkflowLabel</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="computerNameButton">
-							<string key="name">computerNameButton</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="computerNameInput">
-							<string key="name">computerNameInput</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="computerNameTab">
-							<string key="name">computerNameTab</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="errorField">
-							<string key="name">errorField</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="errorTab">
-							<string key="name">errorTab</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="help_menu">
-							<string key="name">help_menu</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="imagingLabel">
-							<string key="name">imagingLabel</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="imagingProgress">
-							<string key="name">imagingProgress</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="imagingProgressDetail">
-							<string key="name">imagingProgressDetail</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="imagingProgressPanel">
-							<string key="name">imagingProgressPanel</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="introTab">
-							<string key="name">introTab</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="loginButton">
-							<string key="name">loginButton</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="loginLabel">
-							<string key="name">loginLabel</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="loginTab">
-							<string key="name">loginTab</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="mainTab">
-							<string key="name">mainTab</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="mainWindow">
-							<string key="name">mainWindow</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="password">
-							<string key="name">password</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="passwordLabel">
-							<string key="name">passwordLabel</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="progressIndicator">
-							<string key="name">progressIndicator</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="progressText">
-							<string key="name">progressText</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="reloadWorkflowsButton">
-							<string key="name">reloadWorkflowsButton</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="reloadWorkflowsMenuItem">
-							<string key="name">reloadWorkflowsMenuItem</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="runWorkflowButton">
-							<string key="name">runWorkflowButton</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="startUpDiskPanel">
-							<string key="name">startUpDiskPanel</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="startUpDiskText">
-							<string key="name">startUpDiskText</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="startupDiskCancelButton">
-							<string key="name">startupDiskCancelButton</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="startupDiskDropdown">
-							<string key="name">startupDiskDropdown</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="startupDiskRestartButton">
-							<string key="name">startupDiskRestartButton</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="theTabView">
-							<string key="name">theTabView</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="utilities_menu">
-							<string key="name">utilities_menu</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="workflowDescription">
-							<string key="name">workflowDescription</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="workflowDescriptionView">
-							<string key="name">workflowDescriptionView</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</dictionary>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../Imagr/MainController.py</string>
-					</object>
-				</object>
-			</array>
-			<array class="NSMutableArray" key="referencedPartialClassDescriptionsV3.2+">
-				<object class="IBPartialClassDescription">
-					<string key="className">NSActionCell</string>
-					<string key="superclassName">NSCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSActionCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSApplication</string>
-					<string key="superclassName">NSResponder</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSApplication.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSButton</string>
-					<string key="superclassName">NSControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSButton.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSButtonCell</string>
-					<string key="superclassName">NSActionCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSButtonCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSCell</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSControl</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSControl.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSFontManager</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSFontManager.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSFormatter</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSFormatter.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSImageCell</string>
-					<string key="superclassName">NSCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSImageCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSImageView</string>
-					<string key="superclassName">NSControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSImageView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSMenu</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSMenu.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSMenuItem</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSMenuItem.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSMenuItemCell</string>
-					<string key="superclassName">NSButtonCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSMenuItemCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSPanel</string>
-					<string key="superclassName">NSWindow</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSPanel.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSPopUpButton</string>
-					<string key="superclassName">NSButton</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSPopUpButton.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSPopUpButtonCell</string>
-					<string key="superclassName">NSMenuItemCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSPopUpButtonCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSProgressIndicator</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSProgressIndicator.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSResponder</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSResponder.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSScrollView</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSScrollView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSScroller</string>
-					<string key="superclassName">NSControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSScroller.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSSecureTextField</string>
-					<string key="superclassName">NSTextField</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="264773600">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSSecureTextField.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSSecureTextFieldCell</string>
-					<string key="superclassName">NSTextFieldCell</string>
-					<reference key="sourceIdentifier" ref="264773600"/>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTabView</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSTabView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTabViewItem</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSTabViewItem.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSText</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSText.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTextField</string>
-					<string key="superclassName">NSControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSTextField.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTextFieldCell</string>
-					<string key="superclassName">NSActionCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSTextFieldCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTextView</string>
-					<string key="superclassName">NSText</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSTextView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSView</string>
-					<string key="superclassName">NSResponder</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSWindow</string>
-					<string key="superclassName">NSResponder</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSWindow.h</string>
-					</object>
-				</object>
-			</array>
-		</object>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
-		<bool key="IBDocument.previouslyAttemptedUpgradeToXcode5">NO</bool>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
-			<integer value="1060" key="NS.object.0"/>
-		</object>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>
-			<integer value="4600" key="NS.object.0"/>
-		</object>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<dictionary class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
-			<string key="NSMenuCheckmark">{11, 11}</string>
-			<string key="NSMenuMixedState">{10, 3}</string>
-			<string key="imagr_icon">{1024, 1024}</string>
-		</dictionary>
-	</data>
-</archive>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+    <dependencies>
+        <deployment version="1060" identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="NSApplication"/>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application">
+            <connections>
+                <outlet property="delegate" destination="373" id="374"/>
+            </connections>
+        </customObject>
+        <menu title="AMainMenu" systemMenu="main" autoenablesItems="NO" id="29" userLabel="MainMenu">
+            <items>
+                <menuItem title="Imagr" id="56">
+                    <menu key="submenu" title="Imagr" systemMenu="apple" autoenablesItems="NO" id="57">
+                        <items>
+                            <menuItem title="About Imagr" id="58">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="orderFrontStandardAboutPanel:" target="-2" id="142"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="143">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                            </menuItem>
+                            <menuItem title="Services" id="131">
+                                <menu key="submenu" title="Services" systemMenu="services" id="130"/>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="144">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                            </menuItem>
+                            <menuItem title="Reload Workflows" enabled="NO" keyEquivalent="r" id="914">
+                                <connections>
+                                    <action selector="reloadWorkflows:" target="664" id="919"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="917">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                            </menuItem>
+                            <menuItem title="Hide Imagr" keyEquivalent="h" id="134">
+                                <connections>
+                                    <action selector="hide:" target="-1" id="367"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Hide Others" keyEquivalent="h" id="145">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="hideOtherApplications:" target="-1" id="368"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Show All" id="150">
+                                <connections>
+                                    <action selector="unhideAllApplications:" target="-1" id="370"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="149">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                            </menuItem>
+                            <menuItem title="Quit Imagr" keyEquivalent="q" id="136" userLabel="1111">
+                                <connections>
+                                    <action selector="terminate:" target="-1" id="369"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="Utilities" id="898">
+                    <menu key="submenu" title="Utilities" id="899"/>
+                </menuItem>
+                <menuItem title="Help" id="103">
+                    <menu key="submenu" title="Help" id="106">
+                        <items>
+                            <menuItem title="Imagr Help" keyEquivalent="?" id="111">
+                                <connections>
+                                    <action selector="showHelp:" target="664" id="974"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+            </items>
+        </menu>
+        <customObject id="373" userLabel="AppDelegate" customClass="AppDelegate">
+            <connections>
+                <outlet property="mainController" destination="664" id="816"/>
+            </connections>
+        </customObject>
+        <customObject id="420" customClass="NSFontManager"/>
+        <customObject id="664" customClass="MainController">
+            <connections>
+                <outlet property="cancelAndRestartButton" destination="474" id="724"/>
+                <outlet property="chooseTargetCancelButton" destination="708" id="718"/>
+                <outlet property="chooseTargetDropDown" destination="706" id="719"/>
+                <outlet property="chooseTargetPanel" destination="703" id="720"/>
+                <outlet property="chooseTargetPanelSelectTarget" destination="707" id="721"/>
+                <outlet property="chooseWorkflowDropDown" destination="748" id="756"/>
+                <outlet property="chooseWorkflowLabel" destination="474" id="757"/>
+                <outlet property="computerNameButton" destination="956" id="961"/>
+                <outlet property="computerNameInput" destination="954" id="960"/>
+                <outlet property="computerNameTab" destination="942" id="962"/>
+                <outlet property="countdownCancelButton" destination="kK1-8K-3pT" id="AWi-46-qrG"/>
+                <outlet property="countdownWarningImage" destination="oKg-z7-CDM" id="2Bd-PI-2ib"/>
+                <outlet property="errorField" destination="476" id="665"/>
+                <outlet property="errorTab" destination="866" id="885"/>
+                <outlet property="imagingLabel" destination="794" id="799"/>
+                <outlet property="imagingProgress" destination="793" id="800"/>
+                <outlet property="imagingProgressDetail" destination="801" id="803"/>
+                <outlet property="imagingProgressPanel" destination="791" id="798"/>
+                <outlet property="introTab" destination="834" id="864"/>
+                <outlet property="loginButton" destination="477" id="666"/>
+                <outlet property="loginLabel" destination="479" id="667"/>
+                <outlet property="loginTab" destination="831" id="842"/>
+                <outlet property="mainTab" destination="830" id="843"/>
+                <outlet property="mainWindow" destination="450" id="697"/>
+                <outlet property="password" destination="478" id="671"/>
+                <outlet property="progressIndicator" destination="836" id="839"/>
+                <outlet property="progressText" destination="837" id="840"/>
+                <outlet property="reloadWorkflowsButton" destination="909" id="912"/>
+                <outlet property="reloadWorkflowsMenuItem" destination="914" id="918"/>
+                <outlet property="runWorkflowButton" destination="774" id="779"/>
+                <outlet property="startUpDiskPanel" destination="452" id="693"/>
+                <outlet property="startUpDiskText" destination="457" id="695"/>
+                <outlet property="startupDiskDropdown" destination="456" id="692"/>
+                <outlet property="startupDiskRestartButton" destination="455" id="694"/>
+                <outlet property="theTabView" destination="829" id="841"/>
+                <outlet property="utilities_menu" destination="899" id="908"/>
+                <outlet property="workflowDescription" destination="762" id="773"/>
+                <outlet property="workflowDescriptionView" destination="761" id="772"/>
+            </connections>
+        </customObject>
+        <window title="Imagr" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" showsToolbarButton="NO" animationBehavior="default" id="450">
+            <windowStyleMask key="styleMask" titled="YES"/>
+            <rect key="contentRect" x="0.0" y="274" width="697" height="503"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
+            <view key="contentView" wantsLayer="YES" focusRingType="none" id="470" userLabel="Container">
+                <rect key="frame" x="0.0" y="0.0" width="697" height="503"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" alphaValue="0.5" id="471">
+                        <rect key="frame" x="-77" y="-1" width="457" height="502"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyUpOrDown" image="imagr_icon" id="484"/>
+                    </imageView>
+                    <tabView drawsBackground="NO" type="noTabsNoBorder" initialItem="834" id="829">
+                        <rect key="frame" x="7" y="8" width="680" height="487"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <font key="font" metaFont="system"/>
+                        <tabViewItems>
+                            <tabViewItem label="Intro" identifier="" id="834">
+                                <view key="view" id="835">
+                                    <rect key="frame" x="0.0" y="0.0" width="680" height="487"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <progressIndicator horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" style="spinning" id="836">
+                                            <rect key="frame" x="324" y="227" width="32" height="32"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                        </progressIndicator>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="837">
+                                            <rect key="frame" x="163" y="267" width="354" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Starting..." id="838">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                    </subviews>
+                                </view>
+                            </tabViewItem>
+                            <tabViewItem label="Login" identifier="1" id="831" userLabel="Login">
+                                <view key="view" id="832">
+                                    <rect key="frame" x="0.0" y="0.0" width="680" height="487"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <textField verticalHuggingPriority="750" id="479">
+                                            <rect key="frame" x="327" y="324" width="354" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Enter Deployment Password" id="480">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <secureTextField verticalHuggingPriority="750" tag="1" id="478" userLabel="Password">
+                                            <rect key="frame" x="329" y="279" width="288" height="37"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" drawsBackground="YES" id="481">
+                                                <font key="font" metaFont="system" size="25"/>
+                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                <allowedInputSourceLocales>
+                                                    <string>NSAllRomanInputSourcesLocaleIdentifier</string>
+                                                </allowedInputSourceLocales>
+                                            </secureTextFieldCell>
+                                            <connections>
+                                                <action selector="login:" target="664" id="679"/>
+                                            </connections>
+                                        </secureTextField>
+                                        <button verticalHuggingPriority="750" id="477">
+                                            <rect key="frame" x="536" y="243" width="87" height="32"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="push" title="Login" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="482">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="login:" target="664" id="678"/>
+                                            </connections>
+                                        </button>
+                                        <textField verticalHuggingPriority="750" id="476" userLabel="Error">
+                                            <rect key="frame" x="332" y="225" width="283" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" id="483">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" red="0.69626783290000005" green="0.0" blue="0.0082080620650000005" alpha="1" colorSpace="calibratedRGB"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                    </subviews>
+                                </view>
+                            </tabViewItem>
+                            <tabViewItem label="Main" identifier="2" id="830" userLabel="Main">
+                                <view key="view" id="833">
+                                    <rect key="frame" x="0.0" y="0.0" width="680" height="487"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <button verticalHuggingPriority="750" id="474">
+                                            <rect key="frame" x="112" y="13" width="134" height="32"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <buttonCell key="cell" type="push" title="Cancel &amp; Restart" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="475">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="setStartupDisk:" target="664" id="696"/>
+                                            </connections>
+                                        </button>
+                                        <button verticalHuggingPriority="750" id="774">
+                                            <rect key="frame" x="442" y="13" width="126" height="32"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="push" title="Run Workflow" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="775">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="runWorkflow:" target="664" id="778"/>
+                                            </connections>
+                                        </button>
+                                        <popUpButton verticalHuggingPriority="750" id="706" userLabel="Target">
+                                            <rect key="frame" x="243" y="362" width="322" height="26"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <popUpButtonCell key="cell" type="push" title="Select target volume" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="711">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="menu"/>
+                                                <menu key="menu" id="712">
+                                                    <items>
+                                                        <menuItem title="Select target volume" state="on" id="713"/>
+                                                        <menuItem title="Item 2" id="714"/>
+                                                        <menuItem title="Item 3" id="715"/>
+                                                    </items>
+                                                </menu>
+                                            </popUpButtonCell>
+                                            <connections>
+                                                <action selector="selectImagingTarget:" target="664" id="941"/>
+                                            </connections>
+                                        </popUpButton>
+                                        <popUpButton verticalHuggingPriority="750" id="748" userLabel="WorkflowPulldown">
+                                            <rect key="frame" x="243" y="331" width="322" height="26"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <popUpButtonCell key="cell" type="push" title="Select workflow" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="749">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="menu"/>
+                                                <menu key="menu" id="750">
+                                                    <items>
+                                                        <menuItem title="Select workflow" state="on" id="751"/>
+                                                        <menuItem title="Item 2" id="752"/>
+                                                        <menuItem title="Item 3" id="753"/>
+                                                    </items>
+                                                </menu>
+                                            </popUpButtonCell>
+                                            <connections>
+                                                <action selector="chooseWorkflowDropDownDidChange:" target="664" id="771"/>
+                                            </connections>
+                                        </popUpButton>
+                                        <scrollView focusRingType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="761" userLabel="Workflow Description">
+                                            <rect key="frame" x="118" y="61" width="444" height="233"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <clipView key="contentView" copiesOnScroll="NO" id="ZQu-RR-yaA">
+                                                <rect key="frame" x="1" y="1" width="442" height="231"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <subviews>
+                                                    <textView editable="NO" selectable="NO" drawsBackground="NO" importsGraphics="NO" verticallyResizable="NO" findStyle="panel" usesRuler="YES" usesFontPanel="YES" allowsNonContiguousLayout="YES" spellingCorrection="YES" id="762">
+                                                        <rect key="frame" x="0.0" y="0.0" width="442" height="231"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                        <color key="backgroundColor" white="1" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                        <size key="minSize" width="442" height="231"/>
+                                                        <size key="maxSize" width="546" height="10000000"/>
+                                                        <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <size key="minSize" width="442" height="231"/>
+                                                        <size key="maxSize" width="546" height="10000000"/>
+                                                    </textView>
+                                                </subviews>
+                                                <color key="backgroundColor" white="1" alpha="0.0" colorSpace="calibratedWhite"/>
+                                            </clipView>
+                                            <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="763">
+                                                <rect key="frame" x="-100" y="-100" width="87" height="18"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                            </scroller>
+                                            <scroller key="verticalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="764">
+                                                <rect key="frame" x="427" y="1" width="16" height="231"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                            </scroller>
+                                        </scrollView>
+                                        <button verticalHuggingPriority="750" id="909">
+                                            <rect key="frame" x="417" y="296" width="151" height="32"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <buttonCell key="cell" type="push" title="Reload Workflows" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="910">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="reloadWorkflows:" target="664" id="913"/>
+                                            </connections>
+                                        </button>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="936">
+                                            <rect key="frame" x="116" y="367" width="97" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Choose Target:" id="937">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="938">
+                                            <rect key="frame" x="116" y="336" width="116" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Choose Workflow:" id="939">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                    </subviews>
+                                </view>
+                            </tabViewItem>
+                            <tabViewItem label="Main" identifier="2" id="866" userLabel="Error">
+                                <view key="view" id="867">
+                                    <rect key="frame" x="0.0" y="0.0" width="680" height="487"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                </view>
+                            </tabViewItem>
+                            <tabViewItem label="Main" identifier="2" id="942" userLabel="Computer Name">
+                                <view key="view" id="943">
+                                    <rect key="frame" x="0.0" y="0.0" width="680" height="487"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="946">
+                                            <rect key="frame" x="242" y="373" width="106" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Computer Name" id="947">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" id="954">
+                                            <rect key="frame" x="244" y="328" width="288" height="37"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="955">
+                                                <font key="font" metaFont="system" size="25"/>
+                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <button verticalHuggingPriority="750" id="956">
+                                            <rect key="frame" x="372" y="292" width="166" height="32"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="push" title="Set Computer Name" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="957">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <action selector="setComputerName:" target="664" id="967"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                    </subviews>
+                                </view>
+                            </tabViewItem>
+                        </tabViewItems>
+                    </tabView>
+                </subviews>
+            </view>
+            <point key="canvasLocation" x="36.5" y="6.5"/>
+        </window>
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" hidesOnDeactivate="YES" oneShot="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="452" userLabel="Restart" customClass="NSPanel">
+            <windowStyleMask key="styleMask" utility="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="120" y="121" width="458" height="86"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
+            <view key="contentView" id="453">
+                <rect key="frame" x="0.0" y="0.0" width="458" height="86"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="457">
+                        <rect key="frame" x="18" y="49" width="422" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Choose Startup Disk" id="458">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <popUpButton verticalHuggingPriority="750" id="456">
+                        <rect key="frame" x="18" y="17" width="342" height="26"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <popUpButtonCell key="cell" type="push" title="Startup Disk" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="463" id="459">
+                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="menu"/>
+                            <menu key="menu" id="460">
+                                <items>
+                                    <menuItem title="Startup Disk" state="on" id="463"/>
+                                    <menuItem title="Item 2" id="462"/>
+                                    <menuItem title="Item 3" id="461"/>
+                                </items>
+                            </menu>
+                        </popUpButtonCell>
+                    </popUpButton>
+                    <button verticalHuggingPriority="750" id="455">
+                        <rect key="frame" x="359" y="13" width="85" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="push" title="Restart" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="464">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="restartButtonClicked:" target="664" id="888"/>
+                        </connections>
+                    </button>
+                </subviews>
+            </view>
+            <point key="canvasLocation" x="-178" y="596"/>
+        </window>
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" hidesOnDeactivate="YES" oneShot="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="703" userLabel="Choose Target" customClass="NSPanel">
+            <windowStyleMask key="styleMask" utility="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="120" y="121" width="512" height="96"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
+            <view key="contentView" id="704">
+                <rect key="frame" x="0.0" y="0.0" width="512" height="96"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <button verticalHuggingPriority="750" id="707" userLabel="Choose Target">
+                        <rect key="frame" x="369" y="23" width="129" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="push" title="Choose Target" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="710">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                        </buttonCell>
+                    </button>
+                    <button verticalHuggingPriority="750" id="708">
+                        <rect key="frame" x="287" y="23" width="83" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="709">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="closeImagingTarget:" target="664" id="722"/>
+                        </connections>
+                    </button>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="968">
+                        <rect key="frame" x="18" y="54" width="95" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Choose Target" id="969">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                </subviews>
+            </view>
+            <point key="canvasLocation" x="442" y="412"/>
+        </window>
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" hidesOnDeactivate="YES" oneShot="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="791" userLabel="Imaging Progress" customClass="NSPanel">
+            <windowStyleMask key="styleMask" titled="YES" utility="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="139" y="81" width="466" height="119"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
+            <view key="contentView" id="792">
+                <rect key="frame" x="0.0" y="0.0" width="466" height="119"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <progressIndicator wantsLayer="YES" maxValue="100" indeterminate="YES" style="bar" id="793">
+                        <rect key="frame" x="91" y="60" width="355" height="20"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    </progressIndicator>
+                    <textField verticalHuggingPriority="750" id="794" userLabel="Imaging Progress Label">
+                        <rect key="frame" x="89" y="87" width="359" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Imaging progress label" id="795">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" id="801" userLabel="Imaging Progress Label">
+                        <rect key="frame" x="89" y="41" width="360" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Imaging progress detail" id="802">
+                            <font key="font" metaFont="smallSystem"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" id="oKg-z7-CDM">
+                        <rect key="frame" x="20" y="41" width="63" height="63"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyUpOrDown" image="NSCaution" id="u70-jx-8D8"/>
+                    </imageView>
+                    <button verticalHuggingPriority="750" id="kK1-8K-3pT">
+                        <rect key="frame" x="371" y="13" width="82" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="B9Y-Po-0h5">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="cancelCountdown:" target="664" id="DB3-r8-eR8"/>
+                        </connections>
+                    </button>
+                </subviews>
+            </view>
+            <point key="canvasLocation" x="-160" y="406"/>
+        </window>
+    </objects>
+    <resources>
+        <image name="NSCaution" width="32" height="32"/>
+        <image name="imagr_icon" width="1024" height="1024"/>
+    </resources>
+</document>

--- a/validateplist
+++ b/validateplist
@@ -21,6 +21,7 @@ This script will validate an Imagr configuration plist. Usage:
     #14 - Partition actions must not be done at first boot
     #15 - eraseVolume actions must not be done at first boot
     #16 - if a default workflow is specified, it must match the name of an existing workflow
+    #17 - if a workflow to autorun is specified, it must match the name of an existing workflow
 """
 
 import os
@@ -183,6 +184,10 @@ def main():
     # Rule 16
     if 'default_workflow' in config and config['default_workflow'] not in existing_names:
         fail('Default workflow must match the name of an existing workflow.')
+
+    # Rule 17
+    if 'autorun' in config and config['autorun'] not in existing_names:
+        fail('Autorun workflow must match the name of an existing workflow')
 
     # if we get this far, it looks good.
     print "SUCCESS: %s looks like a valid Imagr configuration plist." % plist


### PR DESCRIPTION
This PR adds support for automatically running a workflow when Imagr starts.

To use it, set the `autorun` property to the name of an existing workflow.  The `validateplist` script ensures this is properly set.  As this is a top-level property, only one workflow may automatically run (though you are able to include additional workflows if desired).

e.g.

``` xml
<key>autorun</key>
<string>Munki_10103</string>
```

Imagr will begin a 30s countdown.  After this time has elapsed, it will begin executing the workflow specified in `autorun`.  Users have the option to click a Cancel button to stop this from happening.

`default_workflow` only affects the workflow selected in the UI.  Having a password does not prevent autorun from working.
