### PR TITLE
Add background image

### DIFF
--- a/Imagr.xcodeproj/project.pbxproj
+++ b/Imagr.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		050D9F831CE5FF1000250591 /* LLBorderlessWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = 050D9F821CE5FF1000250591 /* LLBorderlessWindow.m */; };
 		C06979C21AE83F3500914535 /* gurl.py in Resources */ = {isa = PBXBuildFile; fileRef = C06979C11AE83F3500914535 /* gurl.py */; };
 		FC21F1741C6235DA0039D923 /* localize.sh in Resources */ = {isa = PBXBuildFile; fileRef = FC21F1731C6235DA0039D923 /* localize.sh */; };
 		FC98DA231AD6B2DC00F90405 /* com.grahamgilbert.first-boot-pkg.plist in Resources */ = {isa = PBXBuildFile; fileRef = FC98DA1F1AD6B2DC00F90405 /* com.grahamgilbert.first-boot-pkg.plist */; };
@@ -59,6 +60,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		050D9F811CE5FF1000250591 /* LLBorderlessWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LLBorderlessWindow.h; sourceTree = "<group>"; };
+		050D9F821CE5FF1000250591 /* LLBorderlessWindow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LLBorderlessWindow.m; sourceTree = "<group>"; };
 		C06979C11AE83F3500914535 /* gurl.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = gurl.py; sourceTree = "<group>"; };
 		FC21F1731C6235DA0039D923 /* localize.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = localize.sh; sourceTree = "<group>"; };
 		FC98DA1F1AD6B2DC00F90405 /* com.grahamgilbert.first-boot-pkg.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "com.grahamgilbert.first-boot-pkg.plist"; sourceTree = "<group>"; };
@@ -195,6 +198,8 @@
 		FCEA80B51AD0101100DBA039 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				050D9F811CE5FF1000250591 /* LLBorderlessWindow.h */,
+				050D9F821CE5FF1000250591 /* LLBorderlessWindow.m */,
 				FCEDFD951AF289E900743302 /* imagr_icon.png */,
 				C06979C11AE83F3500914535 /* gurl.py */,
 				FC98DA1E1AD6B2DC00F90405 /* Resources */,
@@ -382,6 +387,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				050D9F831CE5FF1000250591 /* LLBorderlessWindow.m in Sources */,
 				FCEA80B81AD0101100DBA039 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Imagr/LLBorderlessWindow.h
+++ b/Imagr/LLBorderlessWindow.h
@@ -1,0 +1,18 @@
+//
+//  LLBorderlessWindow.h
+//  Imagr
+//
+//  Created by Per Olofsson on 2016-05-13.
+//  Copyright © 2016 Graham Gilbert. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface LLBorderlessWindow : NSWindow
+
+- (id) initWithContentRect:(NSRect)contentRect
+                 styleMask:(unsigned int)aStyle
+                   backing:(NSBackingStoreType)bufferingType
+                     defer:(BOOL)flag;
+
+@end

--- a/Imagr/LLBorderlessWindow.m
+++ b/Imagr/LLBorderlessWindow.m
@@ -1,0 +1,25 @@
+//
+//  LLBorderlessWindow.m
+//  Imagr
+//
+//  Created by Per Olofsson on 2016-05-13.
+//  Copyright © 2016 Graham Gilbert. All rights reserved.
+//
+
+#import "LLBorderlessWindow.h"
+
+@implementation LLBorderlessWindow
+
+- (id) initWithContentRect:(NSRect)contentRect
+                 styleMask:(unsigned int)aStyle
+                   backing:(NSBackingStoreType)bufferingType
+                     defer:(BOOL)flag
+{
+    self = [super initWithContentRect:contentRect
+                            styleMask:NSBorderlessWindowMask
+                              backing:bufferingType
+                                defer:flag];
+    return self;
+}
+
+@end

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -144,7 +144,6 @@ class MainController(NSObject):
     def runStartupTasks(self):
         self.showBackdropWindow()
         self.mainWindow.center()
-        self.mainWindow.orderFrontRegardless()
         # Run app startup - get the images, password, volumes - anything that takes a while
 
         self.progressText.setStringValue_("Application Starting...")

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -160,7 +160,7 @@ class MainController(NSObject):
         rect = NSScreen.mainScreen().frame()
         self.backdropWindow.setCanBecomeVisibleWithoutLogin_(True)
         self.backdropWindow.setFrame_display_(rect, True)
-        backgroundColor = NSColor.orangeColor()
+        backgroundColor = NSColor.darkGrayColor()
         self.backdropWindow.setBackgroundColor_(backgroundColor)
         self.backdropWindow.setOpaque_(False)
         self.backdropWindow.setIgnoresMouseEvents_(False)
@@ -169,6 +169,15 @@ class MainController(NSObject):
         self.backdropWindow.setLevel_(kCGNormalWindowLevel - 1)
         self.backdropWindow.setCollectionBehavior_(NSWindowCollectionBehaviorStationary | NSWindowCollectionBehaviorCanJoinAllSpaces)
 
+    def loadBackgroundImage(self, url):
+        image = NSImage.alloc().initWithContentsOfURL_(url)
+        self.performSelectorOnMainThread_withObject_waitUntilDone_(
+            self.setBackgroundImage, image, YES)
+    
+    def setBackgroundImage(self, image):
+        self.backdropWindow.contentView().setWantsLayer_(True)
+        self.backdropWindow.contentView().layer().setContents_(image)
+    
     def registerForWorkspaceNotifications(self):
         nc = NSWorkspace.sharedWorkspace().notificationCenter()
         nc.addObserver_selector_name_object_(
@@ -267,6 +276,12 @@ class MainController(NSObject):
 
                 try:
                     self.defaultWorkflow = converted_plist['default_workflow']
+                except:
+                    pass
+                
+                try:
+                    url = NSURL.URLWithString_(converted_plist['background_image'])
+                    NSThread.detachNewThreadSelector_toTarget_withObject_(self.loadBackgroundImage, self, url)
                 except:
                     pass
 

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -14,6 +14,7 @@ from SystemConfiguration import *
 from Foundation import *
 from AppKit import *
 from Cocoa import *
+from Quartz.CoreGraphics import *
 import subprocess
 import sys
 import macdisk
@@ -28,7 +29,8 @@ import time
 class MainController(NSObject):
 
     mainWindow = objc.IBOutlet()
-
+    backdropWindow = objc.IBOutlet()
+    
     utilities_menu = objc.IBOutlet()
     help_menu = objc.IBOutlet()
 
@@ -140,7 +142,9 @@ class MainController(NSObject):
             self.setStartupDisk_(self)
 
     def runStartupTasks(self):
+        self.showBackdropWindow()
         self.mainWindow.center()
+        self.mainWindow.orderFrontRegardless()
         # Run app startup - get the images, password, volumes - anything that takes a while
 
         self.progressText.setStringValue_("Application Starting...")
@@ -150,6 +154,20 @@ class MainController(NSObject):
         self.progressIndicator.startAnimation_(self)
         self.registerForWorkspaceNotifications()
         NSThread.detachNewThreadSelector_toTarget_withObject_(self.loadData, self, None)
+    
+    def showBackdropWindow(self):
+        # Create a backdrop window that covers the whole screen.
+        rect = NSScreen.mainScreen().frame()
+        self.backdropWindow.setCanBecomeVisibleWithoutLogin_(True)
+        self.backdropWindow.setFrame_display_(rect, True)
+        backgroundColor = NSColor.orangeColor()
+        self.backdropWindow.setBackgroundColor_(backgroundColor)
+        self.backdropWindow.setOpaque_(False)
+        self.backdropWindow.setIgnoresMouseEvents_(False)
+        self.backdropWindow.setAlphaValue_(1.0)
+        self.backdropWindow.orderFrontRegardless()
+        self.backdropWindow.setLevel_(kCGNormalWindowLevel - 1)
+        self.backdropWindow.setCollectionBehavior_(NSWindowCollectionBehaviorStationary | NSWindowCollectionBehaviorCanJoinAllSpaces)
 
     def registerForWorkspaceNotifications(self):
         nc = NSWorkspace.sharedWorkspace().notificationCenter()

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -363,6 +363,15 @@ def sendReport(status, message):
         else:
             log.info(log_message)
 
+def bringToFront(bundleID):
+    startTime = time.time()
+    while time.time() - startTime < 10:
+        for runapp in NSRunningApplication.runningApplicationsWithBundleIdentifier_(bundleID):
+            runapp.activateWithOptions_(NSApplicationActivateIgnoringOtherApps)
+            if runapp.isActive():
+                return
+        time.sleep(1/10.0)
+
 def launchApp(app_path):
     # Get the binary path so we can launch it using a threaded subprocess
     try:
@@ -370,23 +379,16 @@ def launchApp(app_path):
         binary = app_plist['CFBundleExecutable']
     except:
         NSLog("Failed to get app binary location, cannot launch.")
-
-    app_list =  NSWorkspace.sharedWorkspace().runningApplications()
-    # Before launching the app, check to see if it is already running
-    app_running = False
-    for app in app_list:
-        if app_plist['CFBundleIdentifier'] == app.bundleIdentifier():
-            app_running = True
-
-    # Only launch the app if it isn't already running
-    if not app_running:
-        thread = CustomThread(os.path.join(app_path,'Contents', 'MacOS', binary))
+        return
+    
+    if not NSRunningApplication.runningApplicationsWithBundleIdentifier_(app_plist['CFBundleIdentifier']):
+        # Only launch the app if it isn't already running
+        thread = CustomThread(os.path.join(app_path, 'Contents', 'MacOS', binary))
         thread.daemon = True
         thread.start()
-        time.sleep(1)
 
     # Bring application to the front as they launch in the background in Netboot for some reason
-    NSWorkspace.sharedWorkspace().launchApplication_(app_path)
+    bringToFront(app_plist['CFBundleIdentifier'])
 
 def get_hardware_info():
     '''Uses system profiler to get hardware info for this machine'''

--- a/Imagr/en.lproj/MainMenu.xib
+++ b/Imagr/en.lproj/MainMenu.xib
@@ -90,6 +90,7 @@
         <customObject id="420" customClass="NSFontManager"/>
         <customObject id="664" customClass="MainController">
             <connections>
+                <outlet property="backdropWindow" destination="58G-aZ-OKf" id="jaI-Lh-m64"/>
                 <outlet property="cancelAndRestartButton" destination="474" id="724"/>
                 <outlet property="chooseTargetCancelButton" destination="708" id="718"/>
                 <outlet property="chooseTargetDropDown" destination="706" id="719"/>
@@ -551,6 +552,16 @@ Gw
                 </subviews>
             </view>
             <point key="canvasLocation" x="-160" y="406"/>
+        </window>
+        <window title="Backdrop Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hasShadow="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="58G-aZ-OKf" customClass="LLBorderlessWindow">
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="0.0" y="0.0" width="480" height="270"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1177"/>
+            <view key="contentView" id="Slo-Fr-LxS">
+                <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </view>
+            <point key="canvasLocation" x="444" y="468"/>
         </window>
     </objects>
     <resources>


### PR DESCRIPTION
This allows you to specify a `background_image` URL in `imagr_config.plist` to hide the ugly gray boot screen. If you no image is specified it displays a grim and colorless gray, with all joy removed.

I'll update the wiki docs if you merge.
