### PR TITLE
Add verify key to image tasks.

### DIFF
--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -701,7 +701,7 @@ class MainController(NSObject):
             # Restore image
             if item.get('type') == 'image' and item.get('url'):
                 Utils.sendReport('in_progress', 'Restoring DMG: %s' % item.get('url'))
-                self.Clone(item.get('url'), self.targetVolume)
+                self.Clone(item.get('url'), self.targetVolume, verify=item.get('verify', True))
             # Download and install package
             elif item.get('type') == 'package' and not item.get('first_boot', True):
                 Utils.sendReport('in_progress', 'Downloading and installing package(s): %s' % item.get('url'))

--- a/validateplist
+++ b/validateplist
@@ -23,6 +23,7 @@ This script will validate an Imagr configuration plist. Usage:
     #16 - if a default workflow is specified, it must match the name of an existing workflow
     #17 - if a workflow to autorun is specified, it must match the name of an existing workflow
     #18 - If a destructive task comes after a non-destructive task, the admin should be warned
+    #19 - If image components have a verify option it must be a bool
 """
 
 import os
@@ -127,6 +128,13 @@ def validate_component(component, workflow):
         if (component['type'] == 'eraseVolume') and (component['first_boot'] is True):
             fail("'eraseVolume' must not be a first-boot action. \
             'first_boot' = True found in %s" % workflow['name'])
+    except:
+        pass
+    
+    # Rule 19
+    try:
+        if (component['type'] == 'image') and (type(component['verify']) != bool):
+            fail("verify must be a bool, found in %s" % workflow['name'])
     except:
         pass
 


### PR DESCRIPTION
Allows you to specify verify true or false for image tasks. Defaults to true, so no change for existing workflows.

```
<dict>
    <key>type</key>
    <string>image</string>
    <key>url</key>
    <string>http://images.example.com/Masters/HFS/osx_updated_160322-10.11.4-15E65.hfs.dmg</string>
    <key>verify</key>
    <false/>
</dict>
```
