### PR TITLE
remove LoginLog Limit to loginwindow

### DIFF
--- a/Imagr/Resources/se.gu.it.LoginLog.plist
+++ b/Imagr/Resources/se.gu.it.LoginLog.plist
@@ -4,10 +4,6 @@
 <dict>
   <key>Label</key>
   <string>se.gu.it.LoginLog</string>
-  <key>LimitLoadToSessionType</key>
-  <array>
-    <string>LoginWindow</string>
-  </array>
   <key>ProgramArguments</key>
   <array>
     <string>/Library/PrivilegedHelperTools/LoginLog.app/Contents/MacOS/LoginLog</string>


### PR DESCRIPTION
### What does this PR do?

Removes the `LimitLoadToSessionType` setting for LoginLog. 
### What issues does this PR fix or reference?

https://derflounder.wordpress.com/2016/06/22/apple-setup-assistant-and-first-boot-package-install-generator-app/
This also came up in the slack channel a few weeks ago. 
### Previous Behavior

On 10.11 machines if `/var/db/.AppleSetupDone` is **not** present on a 10.11 imaged machine LoginLog currently will not show up. Since that is the main way for users to know that the firstboot script is working I'd value it pretty high.
### New Behavior

This _should_ take over Setup Assistant on a 10.11 image. I actually haven't fully tested this yet.

---

In case it isn't obvious this doesn't affect all Imagr users. 
