### PR TITLE
Support for HTTP Basic and Digest authentication for the main (workflows) plist

### DIFF
--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -160,8 +160,15 @@ def post_url(url, post_data, message=None, follow_redirects=False,
         raise HTTPError(connection.status,
                         connection.headers.get('http_result_description', ''))
 
+
+def NSLogWrapper(message):
+    '''A wrapper around NSLog so certain characters sent to NSLog don't trigger string
+    substitution'''
+    NSLog('%@', message)
+
+
 def get_url(url, destinationpath, message=None, follow_redirects=False,
-            progress_method=None, additional_headers=None):
+            progress_method=None, additional_headers=None, username=None, password=None):
     """Gets an HTTP or HTTPS URL and stores it in
     destination path. Returns a dictionary of headers, which includes
     http_result_code and http_result_description.
@@ -181,7 +188,9 @@ def get_url(url, destinationpath, message=None, follow_redirects=False,
                'file': tempdownloadpath,
                'follow_redirects': follow_redirects,
                'additional_headers': header_dict_from_list(additional_headers),
-               'logging_function': NSLog}
+               'username': username,
+               'password': password,
+               'logging_function': NSLogWrapper}
     NSLog('gurl options: %@', options)
 
     connection = Gurl.alloc().initWithOptions_(options)
@@ -271,7 +280,7 @@ def get_url(url, destinationpath, message=None, follow_redirects=False,
         raise HTTPError(connection.status,
                         connection.headers.get('http_result_description', ''))
 
-def downloadFile(url, additional_headers=None):
+def downloadFile(url, additional_headers=None, username=None, password=None):
     url_parse = urlparse.urlparse(url)
     error=None
     error=type("err", (object,), dict())
@@ -279,7 +288,9 @@ def downloadFile(url, additional_headers=None):
         # Use gurl to download the file
         temp_file = os.path.join(tempfile.mkdtemp(), 'tempdata')
         try:
-            headers = get_url(url, temp_file, additional_headers=additional_headers)
+            headers = get_url(
+                url, temp_file, additional_headers=additional_headers,
+                username=username, password=password)
         except HTTPError, err:
             NSLog("HTTP Error: %@", err)
             setattr(error,'reason',err)

--- a/Imagr/en.lproj/MainMenu.xib
+++ b/Imagr/en.lproj/MainMenu.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
     </dependencies>
@@ -90,6 +90,9 @@
         <customObject id="420" customClass="NSFontManager"/>
         <customObject id="664" customClass="MainController">
             <connections>
+                <outlet property="authenticationPanel" destination="dbD-eG-UhW" id="jBL-wm-feh"/>
+                <outlet property="authenticationPanelPasswordField" destination="QDO-gO-Se7" id="nOz-hQ-yXE"/>
+                <outlet property="authenticationPanelUsernameField" destination="OKv-Jz-BhR" id="klU-Ff-DqZ"/>
                 <outlet property="backgroundWindow" destination="58G-aZ-OKf" id="jaI-Lh-m64"/>
                 <outlet property="cancelAndRestartButton" destination="474" id="724"/>
                 <outlet property="chooseTargetCancelButton" destination="708" id="718"/>
@@ -299,10 +302,10 @@ Gw
                                                         <rect key="frame" x="0.0" y="0.0" width="442" height="231"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <color key="backgroundColor" white="1" alpha="0.0" colorSpace="calibratedWhite"/>
-                                                        <size key="minSize" width="427" height="231"/>
+                                                        <size key="minSize" width="442" height="231"/>
                                                         <size key="maxSize" width="546" height="10000000"/>
                                                         <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <size key="minSize" width="427" height="231"/>
+                                                        <size key="minSize" width="442" height="231"/>
                                                         <size key="maxSize" width="546" height="10000000"/>
                                                     </textView>
                                                 </subviews>
@@ -562,6 +565,100 @@ Gw
                 <autoresizingMask key="autoresizingMask"/>
             </view>
             <point key="canvasLocation" x="444" y="468"/>
+        </window>
+        <window title="Authentication Panel" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" hidesOnDeactivate="YES" oneShot="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="dbD-eG-UhW" customClass="NSPanel">
+            <windowStyleMask key="styleMask" titled="YES" utility="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="139" y="81" width="543" height="176"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <view key="contentView" id="AMe-4Q-AaQ">
+                <rect key="frame" x="0.0" y="0.0" width="543" height="176"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <textField verticalHuggingPriority="750" id="OKv-Jz-BhR">
+                        <rect key="frame" x="237" y="97" width="286" height="22"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="u7h-bw-oPA">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <secureTextField verticalHuggingPriority="750" id="QDO-gO-Se7">
+                        <rect key="frame" x="237" y="65" width="286" height="22"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="dkl-YN-y6r">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                            <allowedInputSourceLocales>
+                                <string>NSAllRomanInputSourcesLocaleIdentifier</string>
+                            </allowedInputSourceLocales>
+                        </secureTextFieldCell>
+                    </secureTextField>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="4Tg-eR-Nsb">
+                        <rect key="frame" x="90" y="102" width="141" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Username:" id="nay-XN-m9h">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <button verticalHuggingPriority="750" id="lrS-Bt-WOF">
+                        <rect key="frame" x="421" y="13" width="108" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="push" title="Continue" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="xxz-ug-3xP">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="endAuthenticationPanel:" target="664" id="mbN-Iy-usX"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" id="p6d-qQ-40a">
+                        <rect key="frame" x="310" y="13" width="108" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="push" title="Quit" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Wpo-uc-lhZ">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="cancelAuthenticationPanel:" target="664" id="TNs-zL-oCK"/>
+                        </connections>
+                    </button>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="s4X-1Y-I1k">
+                        <rect key="frame" x="90" y="139" width="292" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Please authenticate to access Imagr workflows." id="j1e-3q-zAs">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" id="TA0-Pu-xaH">
+                        <rect key="frame" x="20" y="92" width="64" height="64"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="imagr_icon" id="tqV-5T-Z1s"/>
+                    </imageView>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="xOf-Ww-Ah8">
+                        <rect key="frame" x="90" y="70" width="141" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Password:" id="JKr-PY-iPY">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                </subviews>
+            </view>
+            <point key="canvasLocation" x="-688.5" y="230"/>
         </window>
     </objects>
     <resources>

--- a/Imagr/gurl.py
+++ b/Imagr/gurl.py
@@ -97,6 +97,11 @@ ssl_error_codes = {
     -9848: u'Configuration error',
     -9849: u'Unexpected (skipped) record in DTLS'}
 
+supported_auth_methods = ['NSURLAuthenticationMethodDefault',
+                          'NSURLAuthenticationMethodHTTPBasic',
+                          'NSURLAuthenticationMethodHTTPDigest',
+                          'NSURLAuthenticationMethodNegotiate',
+                          'NSURLAuthenticationMethodNTLM']
 
 class Gurl(NSObject):
     '''A class for getting content from a URL
@@ -404,10 +409,7 @@ class Gurl(NSObject):
             # we have the wrong credentials. just fail
             self.log('Previous authentication attempt failed.')
             challenge.sender().cancelAuthenticationChallenge_(challenge)
-        if self.username and self.password and authenticationMethod in [
-                'NSURLAuthenticationMethodDefault',
-                'NSURLAuthenticationMethodHTTPBasic',
-                'NSURLAuthenticationMethodHTTPDigest']:
+        if self.username and self.password and authenticationMethod in supported_auth_methods:
             self.log('Will attempt to authenticate.')
             self.log('Username: %s Password: %s'
                      % (self.username, ('*' * len(self.password or ''))))
@@ -442,10 +444,7 @@ class Gurl(NSObject):
             authenticationMethod = protectionSpace.authenticationMethod()
             self.log('Protection space found. Host: %s Realm: %s AuthMethod: %s'
                      % (host, realm, authenticationMethod))
-            if self.username and self.password and authenticationMethod in [
-                    'NSURLAuthenticationMethodDefault',
-                    'NSURLAuthenticationMethodHTTPBasic',
-                    'NSURLAuthenticationMethodHTTPDigest']:
+            if self.username and self.password and authenticationMethod in supported_auth_methods:
                 # we know how to handle this
                 self.log('Can handle this authentication request')
                 return True
@@ -475,10 +474,7 @@ class Gurl(NSObject):
             # we have the wrong credentials. just fail
             self.log('Previous authentication attempt failed.')
             challenge.sender().cancelAuthenticationChallenge_(challenge)
-        if self.username and self.password and authenticationMethod in [
-                'NSURLAuthenticationMethodDefault',
-                'NSURLAuthenticationMethodHTTPBasic',
-                'NSURLAuthenticationMethodHTTPDigest']:
+        if self.username and self.password and authenticationMethod in supported_auth_methods:
             self.log('Will attempt to authenticate.')
             self.log('Username: %s Password: %s'
                      % (self.username, ('*' * len(self.password or ''))))


### PR DESCRIPTION
### What does this PR do?

Adds support for HTTP Basic and Digest authentication for the main (workflows) plist.
### What issues does this PR fix or reference?

https://github.com/grahamgilbert/imagr/issues/152  -- the admin can tie the web server authentication to whatever directory service they have (or any other authentication mechanism)
