### PR TITLE
Force imagr to use universal newlines

### DIFF
--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -330,6 +330,11 @@ def downloadFile(url, additional_headers=None, username=None, password=None):
         data = False
 
     setattr(error, 'url', url)
+    # Force universal newlines so Imagr can handle CRLF and CR file encoding.
+    # This only affects script when they are embedded or file:/// resources.
+    # https://docs.python.org/2/glossary.html#term-universal-newlines
+    if data is not False:
+        data = '\n'.join(data.splitlines())
     return data, error
 
 


### PR DESCRIPTION
### What does this PR do?
This forces Imagr to use universal newlines throughout the workflow config file. I tested this with `file:` and `http:` urls. 

### What issues does this PR fix or reference?
When you save a file with `CRLF` text encoding and have an embedded script component inside the workflow (test file below), Imagr would show the following error message incorrectly. This error is thrown during the run script method. 

![error](https://cloud.githubusercontent.com/assets/2831320/20418230/5645820e-ad11-11e6-8b18-a1a0209d0ea5.png)

Bug was found by @macmule in #imagr slack channel.

### Previous Behavior
Error message above.

### New Behavior
All lines are force encoded as `\n` per python's documentation listed [here](https://docs.python.org/2/glossary.html#term-universal-newlines) using the `splitlines` function.

---

For testing purposes the following file is encoded with `CRLF` and will cause the error message seen above. [windows_CRLF.plist](https://github.com/clburlison/imagr-testing/blob/master/line_break_testing/windows_CRLF.plist). 

(Sorry @macmule I got bored in class and then realized my solution in the slack channel wouldn't work for both schemes. For reference doing `file_handle = open(temp_file, 'U')` does work for the `http:` however that wouldn't have fixed the error for the `file:` scheme.