### PR TITLE
Implement ntpdate subprocess for set_date to set system date/time

### DIFF
--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -383,33 +383,7 @@ def getPlistData(data):
         pass
 
 def set_date():
-    date_data = None
-    time_api_url = 'https://script.google.com/macros/s/AKfycbyd5AcbAnWi2Yn0xhFRbyzS4qMq1VucMVgVvhul5XqS9HkAyJY/exec?tz=UTC'
-
-    try:
-        date_data = urllib2.urlopen(time_api_url, timeout = 1).read()
-    except:
-        pass
-
-    if date_data:
-        try:
-            # Timestamp to epoch
-            utc_data = json.loads(date_data)
-            timestamp = datetime.datetime(
-                                        utc_data['year'],
-                                        utc_data['month'],
-                                        utc_data['day'],
-                                        utc_data['hours'],
-                                        utc_data['minutes'],
-                                        utc_data['seconds'],
-                                        0)
-            # date {month}{day}{hour}{minute}{year}
-            formatted_date = datetime.datetime.strftime(timestamp, '%m%d%H%M%y')
-        
-            subprocess.call(['/bin/date', formatted_date])
-        except:
-            pass
-
+    subprocess.call(['/usr/sbin/ntpdate', '-su', 'time.apple.com'])
 
 def getServerURL():
     return getPlistData('serverurl')

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -383,7 +383,18 @@ def getPlistData(data):
         pass
 
 def set_date():
-    subprocess.call(['/usr/sbin/ntpdate', '-su', 'time.apple.com'])
+    # Try setting system time to time.apple.com via NTP
+    try:
+        subprocess.check_call(['/usr/sbin/ntpdate', '-su', 'time.apple.com'])
+        return
+    except OSError:
+        pass # ntpupdate binary not found
+    except subprocess.CalledProcessError: # try NTP pool if time.apple.com fails
+        try:
+            subprocess.check_call(['/usr/sbin/ntpdate', '-su', 'pool.ntp.org'])
+            return
+        except:
+            pass
 
 def getServerURL():
     return getPlistData('serverurl')

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -396,6 +396,33 @@ def set_date():
         except:
             pass
 
+    date_data = None
+    time_api_url = 'https://script.google.com/macros/s/AKfycbyd5AcbAnWi2Yn0xhFRbyzS4qMq1VucMVgVvhul5XqS9HkAyJY/exec?tz=UTC'
+
+    try:
+        date_data = urllib2.urlopen(time_api_url, timeout = 1).read()
+    except:
+        pass
+
+    if date_data:
+        try:
+            # Timestamp to epoch
+            utc_data = json.loads(date_data)
+            timestamp = datetime.datetime(
+                                        utc_data['year'],
+                                        utc_data['month'],
+                                        utc_data['day'],
+                                        utc_data['hours'],
+                                        utc_data['minutes'],
+                                        utc_data['seconds'],
+                                        0)
+            # date {month}{day}{hour}{minute}{year}
+            formatted_date = datetime.datetime.strftime(timestamp, '%m%d%H%M%y')
+
+            subprocess.call(['/bin/date', formatted_date])
+        except:
+            pass
+
 def getServerURL():
     return getPlistData('serverurl')
 


### PR DESCRIPTION
### What does this PR do?
Updates the set_date function in Utils to use NTP.

### What issues does this PR fix or reference?
Dependence on time website. 

### Previous Behavior
Formats time data pulled over HTTP and uses `date` command to set the system time. 

### New Behavior
Uses the Apple `ntpdate` command (with `-s` for logging to syslog and `-u` for firewall support) to set the system time according to time.apple.com.