### PR TITLE
Get time from Date http header if ntp fails

### DIFF
--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -397,31 +397,26 @@ def set_date():
             pass
 
     date_data = None
-    time_api_url = 'https://script.google.com/macros/s/AKfycbyd5AcbAnWi2Yn0xhFRbyzS4qMq1VucMVgVvhul5XqS9HkAyJY/exec?tz=UTC'
-
+    time_api_url = 'http://www.apple.com'
+    
     try:
-        date_data = urllib2.urlopen(time_api_url, timeout = 1).read()
+        request = urllib2.Request(time_api_url)
+        request.get_method = lambda : 'HEAD'
+        response = request.urlopen(request, timeout=1)
+        date_data = response.info().getheader('Date')
     except:
         pass
 
     if date_data:
         try:
-            # Timestamp to epoch
-            utc_data = json.loads(date_data)
-            timestamp = datetime.datetime(
-                                        utc_data['year'],
-                                        utc_data['month'],
-                                        utc_data['day'],
-                                        utc_data['hours'],
-                                        utc_data['minutes'],
-                                        utc_data['seconds'],
-                                        0)
+            timestamp = datetime.datetime.strptime(date_data, '%a, %d %b %Y %H:%M:%S GMT')
             # date {month}{day}{hour}{minute}{year}
             formatted_date = datetime.datetime.strftime(timestamp, '%m%d%H%M%y')
-
+            
             subprocess.call(['/bin/date', formatted_date])
         except:
             pass
+
 
 def getServerURL():
     return getPlistData('serverurl')

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -402,7 +402,7 @@ def set_date():
     try:
         request = urllib2.Request(time_api_url)
         request.get_method = lambda : 'HEAD'
-        response = request.urlopen(request, timeout=1)
+        response = urllib2.urlopen(request, timeout=1)
         date_data = response.info().getheader('Date')
     except:
         pass


### PR DESCRIPTION
### What does this PR do?
If NTP fails we set the time from the Date HTTP header that we get from www.apple.com.

### What issues does this PR fix or reference?
We don't need an external API or script to get the current time.

### Previous Behavior
Get the time from a script hosted at script.google.com

### New Behavior
Get the time from Date HTTP header at www.apple.com