### PR TITLE
Only set time if needed

### DIFF
--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -324,7 +324,7 @@ class MainController(NSObject):
         pool = NSAutoreleasePool.alloc().init()
         self.volumes = macdisk.MountedVolumes()
         self.buildUtilitiesMenu()
-        Utils.set_date()
+        Utils.setDate()
         theURL = Utils.getServerURL()
 
         if theURL:

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -324,27 +324,34 @@ class MainController(NSObject):
         pool = NSAutoreleasePool.alloc().init()
         self.volumes = macdisk.MountedVolumes()
         self.buildUtilitiesMenu()
-        Utils.setDate()
         theURL = Utils.getServerURL()
 
         if theURL:
-            (plistData, error) = Utils.downloadFile(
-                theURL, username=self.authenticatedUsername, password=self.authenticatedPassword)
-            if error:
-                try:
-                    if error.reason[0] in [401, -1012, -1013]:
-                        # 401:   HTTP status code: authentication required
-                        # -1012: NSURLErrorDomain code "User cancelled authentication" -- returned
-                        #        when we try a given name and password and fail
-                        # -1013: NSURLErrorDomain code "User Authentication Required"
-                        NSLog("Configuration plist requires authentication.")
-                        # show authentication panel using the main thread
-                        self.performSelectorOnMainThread_withObject_waitUntilDone_(
-                            self.showAuthenticationPanel, None, YES)
-                        del pool
-                        return
-                except AttributeError, IndexError:
-                    pass
+            plistData = None
+            tries = 0
+            while (not plistData) and (tries < 3):
+                tries += 1
+                (plistData, error) = Utils.downloadFile(
+                    theURL, username=self.authenticatedUsername, password=self.authenticatedPassword)
+                if error:
+                    try:
+                        if error.reason[0] in [401, -1012, -1013]:
+                            # 401:   HTTP status code: authentication required
+                            # -1012: NSURLErrorDomain code "User cancelled authentication" -- returned
+                            #        when we try a given name and password and fail
+                            # -1013: NSURLErrorDomain code "User Authentication Required"
+                            NSLog("Configuration plist requires authentication.")
+                            # show authentication panel using the main thread
+                            self.performSelectorOnMainThread_withObject_waitUntilDone_(
+                                self.showAuthenticationPanel, None, YES)
+                            del pool
+                            return
+                        elif error.reason[0] < 0:
+                            NSLog("Failed to load configuration plist: %@", repr(error.reason))
+                            # Possibly ssl error due to a bad clock, try setting the time.
+                            Utils.setDate()
+                    except AttributeError, IndexError:
+                        pass
 
             if plistData:
                 try:

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -382,23 +382,41 @@ def getPlistData(data):
     except:
         pass
 
-def set_date():
-    # Try setting system time to time.apple.com via NTP
-    try:
-        subprocess.check_call(['/usr/sbin/ntpdate', '-su', 'time.apple.com'])
+def setDate():
+    # Don't bother if we aren't running as root.
+    if os.getuid() != 0:
         return
-    except OSError:
-        pass # ntpupdate binary not found
-    except subprocess.CalledProcessError: # try NTP pool if time.apple.com fails
+    
+    def success():
+        NSLog("Time successfully set to %@", datetime.datetime.now())
+    
+    def failure():
+        NSLog("Failed to set time")
+    
+    # Try to set time with ntpdate.
+    time_servers = [
+        "time.apple.com",
+        "pool.ntp.org",
+    ]
+    for server in time_servers:
+        NSLog("Trying to set time with ntpdate from %@", server)
         try:
-            subprocess.check_call(['/usr/sbin/ntpdate', '-su', 'pool.ntp.org'])
+            subprocess.check_call(['/usr/sbin/ntpdate', '-su', server])
+            success()
             return
-        except:
-            pass
+        except OSError:
+            # Couldn't execute ntpdate, go to plan B.
+            break
+        except subprocess.CalledProcessError:
+            # Try next server.
+            continue
 
+    # ntpdate failed, so try making a HTTP request and then set the time from
+    # the response header's Date field.
     date_data = None
     time_api_url = 'http://www.apple.com'
     
+    NSLog("Trying to set time with http from %@", time_api_url)
     try:
         request = urllib2.Request(time_api_url)
         request.get_method = lambda : 'HEAD'
@@ -414,8 +432,12 @@ def set_date():
             formatted_date = datetime.datetime.strftime(timestamp, '%m%d%H%M%y')
             
             subprocess.call(['/bin/date', formatted_date])
+            success()
+            return
         except:
             pass
+    
+    failure()
 
 
 def getServerURL():


### PR DESCRIPTION
Setting the time with ntpdate takes a long-ish time. This changes it to only try setting the time if downloading the config plist fails. It also changes it to a no-op if Imagr isn't running as root, to avoid a slow and pointless wait when testing.