### PR TITLE
Use targetVolume.mountpoint when a path string is expected.

### DIFF
--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -270,7 +270,7 @@ class MainController(NSObject):
         self.chooseTargetDropDown.addItemsWithTitles_(volume_list)
         # reselect previously selected target if possible
         if self.targetVolume:
-            self.chooseTargetDropDown.selectItemWithTitle_(self.targetVolume)
+            self.chooseTargetDropDown.selectItemWithTitle_(self.targetVolume.mountpoint)
             selected_volume = self.chooseTargetDropDown.titleOfSelectedItem()
         else:
             selected_volume = volume_list[0]
@@ -553,7 +553,7 @@ class MainController(NSObject):
             if str(volume.mountpoint) == str(volume_name):
                 self.targetVolume = volume
                 break
-        NSLog("Imaging target is %@", self.targetVolume)
+        NSLog("Imaging target is %@", self.targetVolume.mountpoint)
 
 
     @objc.IBAction
@@ -817,7 +817,7 @@ class MainController(NSObject):
                 self.targetVolume.SetStartupDisk()
             except:
                 for volume in self.volumes:
-                    if str(volume.mountpoint) == str(self.targetVolume):
+                    if str(volume.mountpoint) == str(self.targetVolume.mountpoint):
                         volume.SetStartupDisk()
         if self.errorMessage:
             self.theTabView.selectTabViewItem_(self.errorTab)


### PR DESCRIPTION
### What does this PR do?
Updates references to targetVolume that expect a /path/string, not a `macdisk.Disk()` object. This bug caused Imagr to hang on calls to `reloadVolumes()` if targetVolume was set, due to an uncaught ValueError from `chooseTargetDropDown.selectItemWithTitle_()`
### What issues does this PR fix or reference?
Resolves issue #174 