### PR TITLE
check that keyboard_layout_id is integer

### DIFF
--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -576,7 +576,7 @@ def replacePlaceholders(script, target, computer_name=None,
     if computer_name:
         placeholders['{{computer_name}}'] = computer_name
 
-    if keyboard_layout_id:
+    if isinstance(keyboard_layout_id, int):
         placeholders['{{keyboard_layout_id}}'] = keyboard_layout_id
 
     if keyboard_layout_name:


### PR DESCRIPTION
### What does this PR do?
When replacing placeholders in Utils.py, now checks that keyboard_layout_id is integer instead of checking for "truth," because when the value is 0, python interprets "if 'keyboard_layout_id:" as false

### What issues does this PR fix or reference?
No existing GitHub issues that I'm aware of

### Previous Behavior
Localization example shows that keyboard_layout_id should be an integer.
If keyboard_layout_id is an integer of 0, the first boot script for setting locale sets the keyboard_layout_id to "{{keyboard_layout_id}}" instead.

A workaround was to set "keyboard_layout_id" as a string in imagr_config.plist.

### New Behavior
Checks whether keyboard_layout_id is an integer rather than checking keyboard_layout_id for "truth."