### PR TITLE
os.listdir returns items in an arbitrary order

### DIFF
--- a/Imagr/Resources/first-boot
+++ b/Imagr/Resources/first-boot
@@ -98,7 +98,7 @@ Imagr First Boot %s
     sleep_time = 20
     if os.listdir(items_dir):
         # We're installing, wait to see the output
-        for item in os.listdir(items_dir):
+        for item in sorted(os.listdir(items_dir)):
             if item.endswith(".pkg") or item.endswith(".mpkg"):
                 log.info(('%%{color=magenta}Installing %s...') % item)
                 package_path = os.path.join(items_dir, item)


### PR DESCRIPTION
### What does this PR do?
Creates a sorted os.listdir in the imagr first-boot script that handles package installation and script execution
This ensures that packages are installed in the order specified in the imagr workflow

### What issues does this PR fix or reference?
[Bug: first-boot items are not installed in order in macOS High Sierra #184](https://github.com/grahamgilbert/imagr/issues/184)

os.listdir in High Sierra is in arbitrary order.

### Previous Behavior
Scripts and packages were all runnin' around like it was the wild west.

### New Behavior
Packages are installed in order and then scripts are run in order.