### PR TITLE
Fix crash when pkg install fails.

### DIFF
--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1150,7 +1150,7 @@ class MainController(NSObject):
             # Install it
             retcode = self.installPkg(downloaded_file, target, progress_method=progress_method)
             if retcode != 0:
-                self.errorMessage = "Couldn't install %s" % pkg
+                self.errorMessage = "Couldn't install %s" % downloaded_file
                 return False
             # Clean up after ourselves
             shutil.rmtree(temp_dir)


### PR DESCRIPTION
### What does this PR do?
Fixes a crash when a package install fails.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
When a package install fails, if the downloaded pkg isn't wrapped in a dmg, Imagr crashes as it tries to format the error message.

### New Behavior
An error message is displayed.