### PR TITLE
RAM disk

### DIFF
--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1067,7 +1067,7 @@ class MainController(NSObject):
                 devdiskstr = devdisk[0].split(' ')[0]
                 randomnum = random.randint(1000000, 10000000)
                 ramdiskvolname = "ramdisk" + str(randomnum)
-
+                NSLog(u"RAM Disk mountpoint is %@", str(ramdiskvolname))
                 if Utils.is_apfs(source) is True:
                     NSLog(u"Formatting RAM Disk as APFS at %@", devdiskstr)
                     ramformatcommand = ["/sbin/newfs_apfs", "-v",
@@ -1076,8 +1076,8 @@ class MainController(NSObject):
                                                  stdout=subprocess.PIPE,
                                                  stderr=subprocess.PIPE)
                     NSLog(u"Mounting APFS RAM Disk %@", devdiskstr)
-                    rammountcommand = ["/usr/sbin/diskutil", "mount",
-                                       devdiskstr]
+                    rammountcommand = ["/usr/sbin/diskutil", "erasedisk",
+                                       'APFS', ramdiskvolname, devdiskstr]
                     rammount = subprocess.Popen(rammountcommand,
                                                 stdout=subprocess.PIPE,
                                                 stderr=subprocess.PIPE)
@@ -1089,11 +1089,14 @@ class MainController(NSObject):
                                                  stdout=subprocess.PIPE,
                                                  stderr=subprocess.PIPE)
                     NSLog(u"Mounting HFS RAM Disk %@", devdiskstr)
-                    rammountcommand = ["/usr/sbin/diskutil", "mount",
-                                       devdiskstr]
+                    rammountcommand = ["/usr/sbin/diskutil", "erasedisk",
+                                       'HFS+', ramdiskvolname, devdiskstr]
                     rammount = subprocess.Popen(rammountcommand,
                                                 stdout=subprocess.PIPE,
                                                 stderr=subprocess.PIPE)
+                # Wait for the disk to completely initialize
+                NSLog(u"Sleeping 2 seconds to allow full disk initialization.")
+                time.sleep(2)
                 targetpath = os.path.join('/Volumes', ramdiskvolname)
                 NSLog(u"Downloading DMG file from %@", str(source))
                 sourceram = self.downloadDMG(source, targetpath)

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1042,8 +1042,9 @@ class MainController(NSObject):
             memsize = int(
                 memsizetuple[0].split('\n')[0].replace('hw.memsize: ', ''))
             NSLog(u"Total Memory is %@", str(memsize))
-            # Assume netinstall uses at least 500MB of RAM.
-            availablemem = memsize - 524288000
+            # Assume netinstall uses at least 1GB of RAM. If we don't require
+            # enough RAM, gurl will timeout, causing Imagr to crash.
+            availablemem = memsize - 1073741824
             NSLog(u"Available Memory for image is %@", str(availablemem))
             filesize = Utils.getDMGSize(source)[0]
             NSLog(u"Required Memory for image is %@", str(filesize))

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1065,7 +1065,11 @@ class MainController(NSObject):
                 NSLog(u"Error when calculating image size.")
                 NSLog(u"Using asr instead of gurl...")
             elif int(paddedfilesize) > availablemem:
-                NSLog(u"Available Memory is not sufficient for image size. Using asr instead of gurl...")
+                NSLog(u"Available Memory is not sufficient for image size. "
+                      "Using asr instead of gurl...")
+            elif 9000000000 > memsize:
+                NSLog(u"Machine has 8GB of RAM or less. Using asr instead of "
+                      "gurl...")
             else:
                 sectors = int(paddedfilesize) / 512
                 ramstring = "ram://%s" % str(sectors)

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1076,9 +1076,7 @@ class MainController(NSObject):
                                             stderr=subprocess.PIPE)
             targetpath = '/Volumes/ramdisk'
             NSLog(u"Downloading DMG file from %@", str(source))
-            sourceram = self.downloadDMG(
-                source, targetpath,
-                progress_method=self.updateProgressTitle_Percent_Detail_('Downloading %s' % source, -1, ''))
+            sourceram = self.downloadDMG(source, targetpath)
             source = sourceram
 
         is_apfs = False
@@ -1209,19 +1207,20 @@ class MainController(NSObject):
             shutil.rmtree(temp_dir)
 
 
-    def downloadDMG(self, url, target, counter):
+    def downloadDMG(self, url, target):
         if not os.path.basename(url).endswith('.dmg'):
             self.errorMessage = "%s doesn't end with either '.dmg'" % url
             return False
         if os.path.basename(url).endswith('.dmg'):
             # Download it
             dmgname = os.path.basename(url)
-            (downloaded_file, error) = Utils.downloadChunks(url, os.path.join(target,
-            dmgname))
+            (dmg, error) = Utils.downloadChunks(url, os.path.join(target,
+                                                                  dmgname),
+                                                progress_method=self.updateProgressTitle_Percent_Detail_)
             if error:
-                self.errorMessage = "Couldn't download - %s \n %s" % (url, error)
+                self.errorMessage="Couldn't download - %s \n %s" % (url, error)
                 return False
-        return downloaded_file
+        return dmg
 
 
     def downloadAndCopyPackage(self, item, counter):

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1187,6 +1187,12 @@ class MainController(NSObject):
             return False
         if task.poll() == 0:
             self.targetVolume.EnsureMountedWithRefresh()
+            if 'ramdisk' in source:
+                NSLog(u"Detaching RAM Disk post imaging.")
+                detachcommand = ["/usr/bin/hdiutil", "detach", devdiskstr]
+                detach = subprocess.Popen(detachcommand,
+                                          stdout=subprocess.PIPE,
+                                          stderr=subprocess.PIPE)
             return True
 
     def downloadAndInstallPackages(self, item):

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1053,7 +1053,7 @@ class MainController(NSObject):
             elif int(filesize) > availablemem:
                 NSLog(u"Available Memory is not sufficient for image size. Using asr instead of gurl...")
             else:
-                sectors = filesize / 512
+                sectors = int(filesize) / 512
                 ramstring = "ram://%s" % str(sectors)
                 NSLog(u"Amount of Sectors for RAM Disk is %@", str(sectors))
                 ramattachcommand = ["/usr/bin/hdiutil", "attach", "-nomount",

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1248,9 +1248,10 @@ class MainController(NSObject):
                                             stdout=subprocess.PIPE,
                                             stderr=subprocess.PIPE)
             # Wait for the disk to completely initialize
-            NSLog(u"Sleeping 2 seconds to allow full disk initialization.")
-            time.sleep(2)
             targetpath = os.path.join('/Volumes', ramdiskvolname)
+            while not os.path.isdir(targetpath):
+                NSLog(u"Sleeping 1 second to allow full disk initialization.")
+                time.sleep(1)
             if imaging is True:
                 dmgsource = source
             else:

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1051,15 +1051,15 @@ class MainController(NSObject):
             memsize = int(
                 memsizetuple[0].split('\n')[0].replace('hw.memsize: ', ''))
             NSLog(u"Total Memory is %@", str(memsize))
-            # Assume netinstall uses at least 1GB of RAM. If we don't require
-            # enough RAM, gurl will timeout, causing Imagr to crash.
-            availablemem = memsize - 1073741824
+            # Assume netinstall uses at least 650MB of RAM. If we don't require
+            # enough RAM, gurl will timeout or cause RecoveryOS to crash.
+            availablemem = memsize - 681574400
             NSLog(u"Available Memory for image is %@", str(availablemem))
             filesize = Utils.getDMGSize(source)[0]
             NSLog(u"Required Memory for image is %@", str(filesize))
             # Formatting RAM Disk requires around 5% of the total amount of
-            # bytes. Add 7% to compensate for the padding we will need.
-            paddedfilesize = int(filesize) * 1.07
+            # bytes. Add 6% to compensate for the padding we will need.
+            paddedfilesize = int(filesize) * 1.06
             NSLog(u"Padded Memory for image is %@", str(paddedfilesize))
             if filesize is False:
                 NSLog(u"Error when calculating image size.")

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -842,8 +842,7 @@ class MainController(NSObject):
                     item.get('url'),
                     self.targetVolume,
                     verify=item.get('verify', True),
-                    ramdisk=item.get('ramdisk', True),
-                    ramdiskbytes=item.get('ramdiskbytes')
+                    ramdisk=item.get('ramdisk', False),
                 )
             # Download and install package
             elif item.get('type') == 'package' and not item.get('first_boot', True):

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1184,8 +1184,8 @@ class MainController(NSObject):
             filesize = Utils.getDMGSize(source.get('url'))[0]
         NSLog(u"Required Memory for DMG is %@", str(filesize))
         # Formatting RAM Disk requires around 5% of the total amount of
-        # bytes. Add 6% to compensate for the padding we will need.
-        paddedfilesize = int(filesize) * 1.06
+        # bytes. Add 7% to compensate for the padding we will need.
+        paddedfilesize = int(filesize) * 1.07
         NSLog(u"Padded Memory for DMG is %@", str(paddedfilesize))
         if filesize is False:
             NSLog(u"Error when calculating source size. Using original method "

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1006,7 +1006,7 @@ class MainController(NSObject):
         self.workflowOnThreadPrep()
 
     def Clone(self, source, target, erase=True, verify=True,
-              show_activity=True, ramdisk=False, ramdiskbytes=None):
+              show_activity=True, ramdisk=False):
         """A wrapper around 'asr' to clone one disk object onto another.
 
         We run with --puppetstrings so that we get non-buffered output that we

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1267,7 +1267,6 @@ class MainController(NSObject):
                 (dmg, error) = Utils.downloadChunks(url, dmgpath, resume=True,
                                                     progress_method=self.updateProgressTitle_Percent_Detail_)
                 if error:
-                    self.errorMessage="Couldn't download - %s \n %s - retrying..." % (url, error)
                     failsleft -= 1
                     NSLog(u"DMG failed to download - Retries left: %@", str(failsleft))
                 if failsleft == 0:

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1259,7 +1259,7 @@ class MainController(NSObject):
             dmgpath = os.path.join(target, dmgname)
             NSLog(u"DMG Path %@", str(dmgpath))
             while not os.path.isfile(dmgpath):
-                (dmg, error) = Utils.downloadChunks(url, dmgpath,
+                (dmg, error) = Utils.downloadChunks(url, dmgpath, resume=True,
                                                     progress_method=self.updateProgressTitle_Percent_Detail_)
                 if error:
                     self.errorMessage="Couldn't download - %s \n %s - retrying..." % (url, error)

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1350,7 +1350,7 @@ class MainController(NSObject):
             if failsleft == 0:
                 return False
         else:
-            self.errorMessage = "%s doesn't end with either '.dmg'" % url
+            self.errorMessage = "%s doesn't end with '.dmg'" % url
             return False
         return dmg
 

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1114,6 +1114,10 @@ class MainController(NSObject):
                 targetpath = os.path.join('/Volumes', ramdiskvolname)
                 NSLog(u"Downloading DMG file from %@", str(source))
                 sourceram = self.downloadDMG(source, targetpath)
+                if sourceram is False:
+                    self.errorMessage = "DMG Failed to download."
+                    self.targetVolume.EnsureMountedWithRefresh()
+                    return False
                 source = sourceram
 
         is_apfs = False
@@ -1260,8 +1264,9 @@ class MainController(NSObject):
                 if error:
                     self.errorMessage="Couldn't download - %s \n %s - retrying..." % (url, error)
                     failsleft -= 1
+                    NSLog(u"DMG failed to download - Retries left: %@", str(failsleft))
                 if failsleft == 0:
-                    self.errorMessage="Too many download failures. Exiting"
+                    NSLog(u"Too many download failures. Exiting...")
                     break
             if failsleft == 0:
                 return False

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1219,34 +1219,18 @@ class MainController(NSObject):
             randomnum = random.randint(1000000, 10000000)
             ramdiskvolname = "ramdisk" + str(randomnum)
             NSLog(u"RAM Disk mountpoint is %@", str(ramdiskvolname))
-            # Only check for apfs_image status if imaging, startosinstall
-            # should just use apfs since it's meant for 10.13 and higher.
-            if (imaging is True and apfs_image is True) or imaging is False:
-                NSLog(u"Formatting RAM Disk as APFS at %@", devdiskstr)
-                ramformatcommand = ["/sbin/newfs_apfs", "-v",
-                                    ramdiskvolname, devdiskstr]
-                ramformat = subprocess.Popen(ramformatcommand,
-                                             stdout=subprocess.PIPE,
-                                             stderr=subprocess.PIPE)
-                NSLog(u"Mounting APFS RAM Disk %@", devdiskstr)
-                rammountcommand = ["/usr/sbin/diskutil", "erasedisk",
-                                   'APFS', ramdiskvolname, devdiskstr]
-                rammount = subprocess.Popen(rammountcommand,
-                                            stdout=subprocess.PIPE,
-                                            stderr=subprocess.PIPE)
-            else:
-                NSLog(u"Formatting RAM Disk as HFS at %@", devdiskstr)
-                ramformatcommand = ["/sbin/newfs_hfs", "-v",
-                                    ramdiskvolname, devdiskstr]
-                ramformat = subprocess.Popen(ramformatcommand,
-                                             stdout=subprocess.PIPE,
-                                             stderr=subprocess.PIPE)
-                NSLog(u"Mounting HFS RAM Disk %@", devdiskstr)
-                rammountcommand = ["/usr/sbin/diskutil", "erasedisk",
-                                   'HFS+', ramdiskvolname, devdiskstr]
-                rammount = subprocess.Popen(rammountcommand,
-                                            stdout=subprocess.PIPE,
-                                            stderr=subprocess.PIPE)
+            NSLog(u"Formatting RAM Disk as HFS at %@", devdiskstr)
+            ramformatcommand = ["/sbin/newfs_hfs", "-v",
+                                ramdiskvolname, devdiskstr]
+            ramformat = subprocess.Popen(ramformatcommand,
+                                         stdout=subprocess.PIPE,
+                                         stderr=subprocess.PIPE)
+            NSLog(u"Mounting HFS RAM Disk %@", devdiskstr)
+            rammountcommand = ["/usr/sbin/diskutil", "erasedisk",
+                               'HFS+', ramdiskvolname, devdiskstr]
+            rammount = subprocess.Popen(rammountcommand,
+                                        stdout=subprocess.PIPE,
+                                        stderr=subprocess.PIPE)
             # Wait for the disk to completely initialize
             targetpath = os.path.join('/Volumes', ramdiskvolname)
             while not os.path.isdir(targetpath):

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1115,6 +1115,11 @@ class MainController(NSObject):
                 NSLog(u"Downloading DMG file from %@", str(source))
                 sourceram = self.downloadDMG(source, targetpath)
                 if sourceram is False:
+                    NSLog(u"Detaching RAM Disk due to failure.")
+                    detachcommand = ["/usr/bin/hdiutil", "detach", devdiskstr]
+                    detach = subprocess.Popen(detachcommand,
+                                              stdout=subprocess.PIPE,
+                                              stderr=subprocess.PIPE)
                     self.errorMessage = "DMG Failed to download."
                     self.targetVolume.EnsureMountedWithRefresh()
                     return False

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1332,9 +1332,6 @@ class MainController(NSObject):
 
 
     def downloadDMG(self, url, target):
-        if not os.path.basename(url).endswith('.dmg'):
-            self.errorMessage = "%s doesn't end with either '.dmg'" % url
-            return False
         if os.path.basename(url).endswith('.dmg'):
             # Download it
             dmgname = os.path.basename(url)
@@ -1352,6 +1349,9 @@ class MainController(NSObject):
                     break
             if failsleft == 0:
                 return False
+        else:
+            self.errorMessage = "%s doesn't end with either '.dmg'" % url
+            return False
         return dmg
 
 

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1242,11 +1242,19 @@ class MainController(NSObject):
         if os.path.basename(url).endswith('.dmg'):
             # Download it
             dmgname = os.path.basename(url)
-            (dmg, error) = Utils.downloadChunks(url, os.path.join(target,
-                                                                  dmgname),
-                                                progress_method=self.updateProgressTitle_Percent_Detail_)
-            if error:
-                self.errorMessage="Couldn't download - %s \n %s" % (url, error)
+            failsleft = 3
+            dmgpath = os.path.join(target, dmgname)
+            NSLog(u"DMG Path %@", str(dmgpath))
+            while not os.path.isfile(dmgpath):
+                (dmg, error) = Utils.downloadChunks(url, dmgpath,
+                                                    progress_method=self.updateProgressTitle_Percent_Detail_)
+                if error:
+                    self.errorMessage="Couldn't download - %s \n %s - retrying..." % (url, error)
+                    failsleft -= 1
+                if failsleft == 0:
+                    self.errorMessage="Too many download failures. Exiting"
+                    break
+            if failsleft == 0:
                 return False
         return dmg
 

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1048,13 +1048,17 @@ class MainController(NSObject):
             NSLog(u"Available Memory for image is %@", str(availablemem))
             filesize = Utils.getDMGSize(source)[0]
             NSLog(u"Required Memory for image is %@", str(filesize))
+            # Formatting RAM Disk requires around 5% of the total amount of
+            # bytes. Add 7% to compensate for the padding we will need.
+            paddedfilesize = int(filesize) * 1.07
+            NSLog(u"Padded Memory for image is %@", str(paddedfilesize))
             if filesize is False:
                 NSLog(u"Error when calculating image size.")
                 NSLog(u"Using asr instead of gurl...")
-            elif int(filesize) > availablemem:
+            elif int(paddedfilesize) > availablemem:
                 NSLog(u"Available Memory is not sufficient for image size. Using asr instead of gurl...")
             else:
-                sectors = int(filesize) / 512
+                sectors = int(paddedfilesize) / 512
                 ramstring = "ram://%s" % str(sectors)
                 NSLog(u"Amount of Sectors for RAM Disk is %@", str(sectors))
                 ramattachcommand = ["/usr/bin/hdiutil", "attach", "-nomount",

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1184,8 +1184,8 @@ class MainController(NSObject):
             filesize = Utils.getDMGSize(source.get('url'))[0]
         NSLog(u"Required Memory for DMG is %@", str(filesize))
         # Formatting RAM Disk requires around 5% of the total amount of
-        # bytes. Add 7% to compensate for the padding we will need.
-        paddedfilesize = int(filesize) * 1.07
+        # bytes. Add 10% to compensate for the padding we will need.
+        paddedfilesize = int(filesize) * 1.10
         NSLog(u"Padded Memory for DMG is %@", str(paddedfilesize))
         if filesize is False:
             NSLog(u"Error when calculating source size. Using original method "

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -98,7 +98,7 @@ def post_url(url, post_data, message=None, follow_redirects=False,
             if message and connection.status and connection.status != 304:
                 # log always, display if verbose is 1 or more
                 # also display in progress field
-                NSLog(message)
+                NSLog('%@', message)
                 if progress_method:
                     progress_method(None, None, message)
                 # now clear message so we don't display it again
@@ -215,7 +215,7 @@ def get_url(url, destinationpath, message=None, follow_redirects=False,
             if message and connection.status and connection.status != 304:
                 # log always, display if verbose is 1 or more
                 # also display in progress field
-                NSLog(message)
+                NSLog('%@', message)
                 if progress_method:
                     progress_method(None, None, message)
                 # now clear message so we don't display it again

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -354,6 +354,29 @@ def downloadFile(url, additional_headers=None, username=None, password=None):
     return data, error
 
 
+def getDMGSize(url):
+    url_parse = urlparse.urlparse(url)
+    error = None
+    error = type("err", (object,), dict())
+    if url_parse.scheme in ['http', 'https']:
+        request = urllib2.Request(url)
+        try:
+            dmg = urllib2.urlopen(request)
+            data = dmg.headers['Content-Length']
+        except urllib2.URLError, err:
+            setattr(error, 'reason', err)
+            data = False
+        except urllib2.HTTPError, err:
+            setattr(error, 'reason', err)
+            data = False
+    else:
+        setattr(error, 'reason', 'The following URL is unsupported')
+        data = False
+
+    setattr(error, 'url', url)
+    return data, error
+
+
 def getPasswordHash(password):
     return hashlib.sha512(password).hexdigest()
 

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -177,7 +177,7 @@ def NSLogWrapper(message):
 
 def get_url(url, destinationpath, message=None, follow_redirects=False,
             progress_method=None, additional_headers=None, username=None,
-            password=None):
+            password=None, resume=False):
     """Gets an HTTP or HTTPS URL and stores it in
     destination path. Returns a dictionary of headers, which includes
     http_result_code and http_result_description.
@@ -197,6 +197,7 @@ def get_url(url, destinationpath, message=None, follow_redirects=False,
                'file': tempdownloadpath,
                'follow_redirects': follow_redirects,
                'additional_headers': header_dict_from_list(additional_headers),
+               'can_resume': resume,
                'username': username,
                'password': password,
                'logging_function': NSLogWrapper}
@@ -679,13 +680,13 @@ def unmountdmg(mountpoint):
         return True
 
 
-def downloadChunks(url, file, progress_method=None, additional_headers=None):
+def downloadChunks(url, file, progress_method=None, additional_headers=None, resume=False):
     message = "Downloading %s" % os.path.basename(url)
     url_parse = urlparse.urlparse(url)
     if url_parse.scheme in ['http', 'https']:
         # Use gurl to download the file
         try:
-            headers = get_url(url, file, message=message,
+            headers = get_url(url, file, message=message, resume=resume,
                               progress_method=progress_method,
                               additional_headers=additional_headers)
             return file, None

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -689,12 +689,12 @@ def downloadChunks(url, file, progress_method=None, additional_headers=None):
                               progress_method=progress_method,
                               additional_headers=additional_headers)
             return file, None
-        except HTTPError, err:
-            NSLog("HTTP Error: %@", err)
-            return False, err
-        except GurlError, err:
-            NSLog("Gurl Error: %@", err)
-            return False, err
+        except HTTPError, error:
+            NSLog("HTTP Error: %@", error)
+            return False, error
+        except GurlError, error:
+            NSLog("Gurl Error: %@", error)
+            return False, error
     elif url_parse.scheme == 'file':
         # File resources should be handled natively. Space characters, %20,
         # need to be removed

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -364,10 +364,7 @@ def getDMGSize(url):
         try:
             dmg = urllib2.urlopen(request)
             data = dmg.headers['Content-Length']
-        except urllib2.URLError, err:
-            setattr(error, 'reason', err)
-            data = False
-        except urllib2.HTTPError, err:
+        except (urllib2.URLError, urllib2.HTTPError), err:
             setattr(error, 'reason', err)
             data = False
     else:


### PR DESCRIPTION
### What does this PR do?
This adds an option to use a RAM disk with the `image` component.

### New Behavior
Add the following to your config.plist image component

```xml
          <key>ramdisk</key>
          <true/>
```

Imagr will get the `Content-Length` of the dmg file and if there is enough available RAM, it will create a RAM disk and use it, otherwise it will just fallback to asr. If urllib2 cannot validate SSL (say connecting to TLS 1.2 on a pre 10.13 NBI), it will also fallback to asr.

This allows us to utilize gurl to download the DMG vs asr. gurl is significantly more performant in both local and CDN downloads, allowing a faster imaging proceess.