### PR TITLE
Add support for `startosinstall` workflow component

### DIFF
--- a/Imagr.xcodeproj/project.pbxproj
+++ b/Imagr.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		100FA3EC1D51DC6C000F1C1C /* powermgr.py in Resources */ = {isa = PBXBuildFile; fileRef = 100FA3EB1D51DC6C000F1C1C /* powermgr.py */; };
 		10DA31C31D92963A00969112 /* se.gu.it.LoginLog.login.plist in Resources */ = {isa = PBXBuildFile; fileRef = 10DA31C21D92963A00969112 /* se.gu.it.LoginLog.login.plist */; };
 		C06979C21AE83F3500914535 /* gurl.py in Resources */ = {isa = PBXBuildFile; fileRef = C06979C11AE83F3500914535 /* gurl.py */; };
+		C0D0AB191F8C36FC001B1CF3 /* osinstall.py in Resources */ = {isa = PBXBuildFile; fileRef = C0D0AB181F8C36FC001B1CF3 /* osinstall.py */; };
+		C0D0AB1D1F8C3D03001B1CF3 /* ptyexec in Resources */ = {isa = PBXBuildFile; fileRef = C0D0AB1C1F8C3D03001B1CF3 /* ptyexec */; };
 		FC21F1741C6235DA0039D923 /* localize.sh in Resources */ = {isa = PBXBuildFile; fileRef = FC21F1731C6235DA0039D923 /* localize.sh */; };
 		FC98DA231AD6B2DC00F90405 /* com.grahamgilbert.imagr-first-boot-pkg.plist in Resources */ = {isa = PBXBuildFile; fileRef = FC98DA1F1AD6B2DC00F90405 /* com.grahamgilbert.imagr-first-boot-pkg.plist */; };
 		FC98DA241AD6B2DC00F90405 /* first-boot in Resources */ = {isa = PBXBuildFile; fileRef = FC98DA201AD6B2DC00F90405 /* first-boot */; };
@@ -67,6 +69,8 @@
 		100FA3EB1D51DC6C000F1C1C /* powermgr.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = powermgr.py; sourceTree = "<group>"; };
 		10DA31C21D92963A00969112 /* se.gu.it.LoginLog.login.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = se.gu.it.LoginLog.login.plist; sourceTree = "<group>"; };
 		C06979C11AE83F3500914535 /* gurl.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = gurl.py; sourceTree = "<group>"; };
+		C0D0AB181F8C36FC001B1CF3 /* osinstall.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = osinstall.py; sourceTree = "<group>"; };
+		C0D0AB1C1F8C3D03001B1CF3 /* ptyexec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = ptyexec; sourceTree = "<group>"; };
 		FC21F1731C6235DA0039D923 /* localize.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = localize.sh; sourceTree = "<group>"; };
 		FC98DA1F1AD6B2DC00F90405 /* com.grahamgilbert.imagr-first-boot-pkg.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "com.grahamgilbert.imagr-first-boot-pkg.plist"; sourceTree = "<group>"; };
 		FC98DA201AD6B2DC00F90405 /* first-boot */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = "first-boot"; sourceTree = "<group>"; };
@@ -138,6 +142,7 @@
 		FC98DA1E1AD6B2DC00F90405 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				C0D0AB1C1F8C3D03001B1CF3 /* ptyexec */,
 				FC21F1731C6235DA0039D923 /* localize.sh */,
 				FCED84641B0201B20072AC1C /* set_computer_name.sh */,
 				FC98DA1F1AD6B2DC00F90405 /* com.grahamgilbert.imagr-first-boot-pkg.plist */,
@@ -217,6 +222,7 @@
 				FCEA80B61AD0101100DBA039 /* Info.plist */,
 				FCEA80B71AD0101100DBA039 /* main.m */,
 				FCEA80B91AD0101100DBA039 /* Credits.rtf */,
+				C0D0AB181F8C36FC001B1CF3 /* osinstall.py */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -350,6 +356,7 @@
 				FCEDFD961AF289E900743302 /* imagr_icon.png in Resources */,
 				FCEA80F61AD018E500DBA039 /* cocoadialog.py in Resources */,
 				FCEA81041AD018E500DBA039 /* systemconfig.py in Resources */,
+				C0D0AB191F8C36FC001B1CF3 /* osinstall.py in Resources */,
 				FCEA80C01AD0101100DBA039 /* main.py in Resources */,
 				FCEA81001AD018E500DBA039 /* macdisk.py in Resources */,
 				FCF6B30F1AD1D73E00311D3A /* Installer.icns in Resources */,
@@ -365,6 +372,7 @@
 				FCEA80C51AD0101100DBA039 /* MainMenu.xib in Resources */,
 				FCEA810B1AD02C9A00DBA039 /* Utils.py in Resources */,
 				FCEA80F71AD018E500DBA039 /* defaults.py in Resources */,
+				C0D0AB1D1F8C3D03001B1CF3 /* ptyexec in Resources */,
 				FCEA80F91AD018E500DBA039 /* ds_test.py in Resources */,
 				100FA3EC1D51DC6C000F1C1C /* powermgr.py in Resources */,
 				FCEA80FC1AD018E500DBA039 /* getauth.py in Resources */,

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -26,6 +26,7 @@ import shutil
 import Quartz
 import time
 import powermgr
+import osinstall
 
 class MainController(NSObject):
 
@@ -843,6 +844,10 @@ class MainController(NSObject):
                     self.targetVolume,
                     verify=item.get('verify', True)
                 )
+            # startosinstall
+            elif item.get('type') == 'startosinstall':
+                Utils.sendReport('in_progress', 'starting macOS install: %s' % item.get('url'))
+                self.startOSinstall(item)
             # Download and install package
             elif item.get('type') == 'package' and not item.get('first_boot', True):
                 Utils.sendReport('in_progress', 'Downloading and installing package(s): %s' % item.get('url'))
@@ -1091,6 +1096,15 @@ class MainController(NSObject):
         if task.poll() == 0:
             self.targetVolume.EnsureMountedWithRefresh()
             return True
+
+    def startOSinstall(self, item):
+        self.updateProgressTitle_Percent_Detail_(
+            'Preparing macOS install...', -1, '')
+        success, detail = osinstall.run(
+            item, self.targetVolume.mountpoint,
+            progress_method=self.updateProgressTitle_Percent_Detail_)
+        if not success:
+            self.errorMessage = detail
 
     def downloadAndInstallPackages(self, item):
         url = item.get('url')

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1184,8 +1184,6 @@ class MainController(NSObject):
             self.errorMessage = "Error copying first boot package %s - %s" % (url, error)
             return False
 
-
-
     def downloadPackage(self, url, target, number, progress_method=None, additional_headers=None):
         error = None
         dest_dir = os.path.join(target, 'usr/local/first-boot/items')

--- a/Imagr/Resources/ptyexec
+++ b/Imagr/Resources/ptyexec
@@ -1,0 +1,128 @@
+#!/usr/bin/python
+# encoding: utf-8
+#
+# Copyright 2011-2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+ptyexec
+
+Created by John Randolph 2011-08-11.
+
+Utility script to run a subprocess in a pseudo tty.
+
+This will have the effect of unbuffering output I/O from the subprocess.
+stdin of the subprocess is not connected to the stdin of this parent
+process.
+"""
+
+import fcntl
+import os
+import pty
+import select
+import signal
+import sys
+
+
+child_exited = {}
+
+
+def SetFileNonBlocking(f, non_blocking=True):
+    """Set non-blocking flag on a file object.
+
+    Args:
+        f: file
+        non_blocking: bool, default True, non-blocking mode or not
+    """
+    flags = fcntl.fcntl(f.fileno(), fcntl.F_GETFL)
+    if bool(flags & os.O_NONBLOCK) != non_blocking:
+        flags ^= os.O_NONBLOCK
+    fcntl.fcntl(f.fileno(), fcntl.F_SETFL, flags)
+
+
+def SigHandler(signum, frame):
+    """Handle a signal.
+
+    Args:
+        signum: int, signal number
+        frame: frame, stack frame where signal was received
+    """
+    global child_exited
+
+    if signum == signal.SIGCHLD:
+        x = os.waitpid(-1, 0)
+        if x[0] > 0:
+            child_exited[x[0]] = x[1] >> 8    # get exit status from LSB
+
+
+def Usage(arg0):
+    """Print usage."""
+    print >>sys.stderr, 'Usage: %s [command to run] [arguments...]' % arg0
+    return 0
+
+
+def PtyExec(argv):
+    """Setup pty and exec argv.
+
+    Args:
+        argv: list, arguments
+    Returns:
+        int, status code from child process upon completion, or 1 if a fork
+            error occurs.
+        never returns on the child side of the fork.
+    """
+    signal.signal(signal.SIGCHLD, SigHandler)
+    pid, fd = pty.fork()
+
+    if pid == 0:         # child
+        try:
+            os.execv(argv[0], argv)
+        except OSError, e:
+            print >>sys.stderr, str(e)
+            sys.exit(1)
+    elif pid > 0:        # parent
+        f = os.fdopen(fd, 'r+', 0)
+        SetFileNonBlocking(f)
+        while 1:
+            try:
+                (rl, wl, xl) = select.select([f], [], [], 5.0)
+            except select.error, e:
+                rl = []
+
+            if f in rl:
+                l = f.read()
+                sys.stdout.write(l)
+                sys.stdout.flush()
+
+            if pid in child_exited:
+                break
+
+        f.close()
+    elif pid == -1:    # error, never forked.
+        print >>sys.stderr, 'fork() error'
+        return 1
+
+    return child_exited.get(pid, 1)
+
+
+def main(argv):
+    """Main."""
+    if len(argv) < 2:
+        return Usage(argv[0])
+
+    argv.pop(0)
+    return PtyExec(argv)
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/Imagr/osinstall.py
+++ b/Imagr/osinstall.py
@@ -1,0 +1,179 @@
+# encoding: utf-8
+#
+# Copyright 2017 Greg Neagle.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+osinstall.py
+
+Created by Greg Neagle on 2017-10-09.
+
+Support for using startosinstall to install macOS.
+"""
+
+# stdlib imports
+import os
+import subprocess
+
+# PyObjC bindings
+from Foundation import NSLog
+
+# our imports
+import FoundationPlist
+import Utils
+
+
+def find_install_macos_app(dir_path):
+    '''Returns the path to the first Install macOS.app found the top level of
+    dir_path, or None'''
+    for item in os.listdir(dir_path):
+        item_path = os.path.join(dir_path, item)
+        startosinstall_path = os.path.join(
+            item_path, 'Contents/Resources/startosinstall')
+        if os.path.exists(startosinstall_path):
+            return item_path
+    # if we get here we didn't find one
+    return None
+
+
+def install_macos_app_is_stub(app_path):
+    '''High Sierra downloaded installer is sometimes a "stub" application that
+    does not contain the InstallESD.dmg. Retune True if the given app path is
+    missing the InstallESD.dmg'''
+    installesd_dmg = os.path.join(
+        app_path, 'Contents/SharedSupport/InstallESD.dmg')
+    return not os.path.exists(installesd_dmg)
+
+
+def get_os_version(app_path):
+    '''Returns the os version from the OS Installer app'''
+    installinfo_plist = os.path.join(
+        app_path, 'Contents/SharedSupport/InstallInfo.plist')
+    if not os.path.isfile(installinfo_plist):
+        # no Contents/SharedSupport/InstallInfo.plist
+        return ''
+    try:
+        info = FoundationPlist.readPlist(installinfo_plist)
+        return info['System Image Info']['version']
+    except (FoundationPlist.FoundationPlistException,
+            IOError, KeyError, AttributeError, TypeError):
+        return ''
+
+
+def run(item, target, progress_method=None):
+    '''Run startosinstall from Install macOS app on a disk image'''
+    url = item.get('url')
+    # url better point to a disk image containing the Install macOS app
+    try:
+        dmgmountpoints = Utils.mountdmg(url)
+        dmgmountpoint = dmgmountpoints[0]
+    except:
+        error_message = "Couldn't mount disk image from %s" % url
+        return False, error_message
+
+    app_path = find_install_macos_app(dmgmountpoint)
+    startosinstall_path = os.path.join(
+        app_path, 'Contents/Resources/startosinstall')
+
+    # we need to wrap our call to startosinstall with a utility
+    # that makes startosinstall think it is connected to a tty-like
+    # device so its output is unbuffered so we can get progress info
+    # otherwise we get nothing until the process exits.
+    #
+    # Try to find our ptyexec tool
+    # first look in the this file's enclosing directory
+    # (../)
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    ptyexec_path = os.path.join(this_dir, 'ptyexec')
+    if os.path.exists(ptyexec_path):
+        cmd = [ptyexec_path]
+    else:
+        # fall back to /usr/bin/script
+        # this is not preferred because it uses way too much CPU
+        # checking stdin for input that will never come...
+        cmd = ['/usr/bin/script', '-q', '-t', '1', '/dev/null']
+
+    cmd.extend([startosinstall_path,
+                '--agreetolicense',
+                '--applicationpath', app_path,
+                '--volume', target,
+                '--nointeraction'])
+
+    if 'additional_startosinstall_options' in item:
+        cmd.extend(item['additional_startosinstall_options'])
+
+    # more magic to get startosinstall to not buffer its output for
+    # percent complete
+    env = {'NSUnbufferedIO': 'YES'}
+
+    proc = subprocess.Popen(
+        cmd, shell=False, bufsize=-1, env=env,
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    startosinstall_output = []
+    while True:
+        output = proc.stdout.readline()
+        if not output and (proc.returncode != None):
+            break
+        info_output = output.rstrip('\n').decode('UTF-8')
+        # save all startosinstall output in case there is
+        # an error so we can dump it to the log
+        startosinstall_output.append(info_output)
+
+        # parse output for useful progress info
+        msg = info_output.rstrip('\n')
+        if msg.startswith('Preparing to '):
+            NSLog('%@', msg)
+            if progress_method:
+                progress_method(None, None, msg)
+        elif msg.startswith('Preparing '):
+            # percent-complete messages
+            try:
+                percent = int(float(msg[10:].rstrip().rstrip('.')))
+            except ValueError:
+                percent = -1
+            if progress_method:
+                progress_method(None, percent, None)
+        elif msg.startswith(('By using the agreetolicense option',
+                             'If you do not agree,')):
+            # annoying legalese
+            pass
+        elif msg.startswith('Helper tool cr'):
+            # no need to print that stupid message to screen!
+            # 10.12: 'Helper tool creashed'
+            # 10.13: 'Helper tool crashed'
+            NSLog('%@', msg)
+        elif msg.startswith(
+                ('Signaling PID:', 'Waiting to reboot',
+                 'Process signaled okay')):
+            # messages around the SIGUSR1 signalling
+            NSLog('%@', msg)
+        elif msg.startswith('System going down for install'):
+            msg = 'System will restart and begin install of macOS.'
+            NSLog('%@', msg)
+            if progress_method:
+                progress_method(None, None, msg)
+        else:
+            # none of the above, just display
+            NSLog('%@', msg)
+            if progress_method:
+                progress_method(None, None, msg)
+
+    return_code = proc.returncode
+    errors = proc.stderr.read()
+    if return_code != 0:
+        NSLog('##### startosinstall stderr: #####')
+        NSLog('%@', errors)
+        return False, 'startosinstall failed with return code %s' % return_code
+    else:
+        return True, 'OK'

--- a/Imagr/osinstall.py
+++ b/Imagr/osinstall.py
@@ -77,14 +77,15 @@ class PkgCachingError(Exception):
     pass
 
 
-def cache_pkg(url, dest_dir, progress_method=None):
+def cache_pkg(url, dest_dir, progress_method=None, additional_headers=None):
     '''Download and cache a package'''
     error = None
     package_name = os.path.basename(url)
     os.umask(0002)
     pkgpath = os.path.join(dest_dir, package_name)
     (_, error) = Utils.downloadChunks(
-        url, pkgpath, progress_method=progress_method)
+        url, pkgpath,
+        progress_method=progress_method, additional_headers=additional_headers)
     if error:
         raise PkgCachingError(
             'Error downloading %s - %s' % (url, error))
@@ -129,7 +130,8 @@ def cache_pkg_from_dmg(url, dest_dir):
     return dest_file
 
 
-def download_and_cache_pkgs(pkgurls, target, progress_method=None):
+def download_and_cache_pkgs(
+        pkgurls, target, progress_method=None, additional_headers=None):
     '''Given a list of urls to packages, download the pkgs and stash them
     on the target volume. Return a list of the stashed paths.
     Raise PkgCaching error if there is a problem'''
@@ -146,7 +148,9 @@ def download_and_cache_pkgs(pkgurls, target, progress_method=None):
         if os.path.basename(url).endswith('.dmg'):
             pkgpath = cache_pkg_from_dmg(url, dest_dir)
         else:
-            pkgpath = cache_pkg(url, dest_dir, progress_method=progress_method)
+            pkgpath = cache_pkg(
+                url, dest_dir, progress_method=progress_method,
+                additional_headers=additional_headers)
         pkgpaths.append(pkgpath)
 
     return pkgpaths
@@ -175,7 +179,8 @@ def run(item, target, progress_method=None):
         try:
             additional_package_paths = download_and_cache_pkgs(
                 item['additional_package_urls'], target,
-                progress_method=progress_method)
+                progress_method=progress_method,
+                additional_headers=item.get('additional_headers'))
         except PkgCachingError, err:
             return False, unicode(err)
 

--- a/startosinstall_notes.md
+++ b/startosinstall_notes.md
@@ -155,3 +155,25 @@ This uses package components that install at first boot. These are cached on the
 
 Brief testing shows this works (at least for 10.13 installs), but the UI is bad:
 After the macOS install is complete and the machine boots to the new OS, it sits at a black screen while the cached packages are installed: LoginLog.app does not display a UI.
+
+#### Testing notes
+
+In the same directory as the cloned repo, make a `config.mk` file. Recommended contents:
+
+```
+BUILD=Testing
+STARTTERMINAL=True
+APP="/Applications/Install macOS Sierra.app" # if you are building on Sierra
+APP="/Applications/Install macOS High Sierra.app" # if you are building on HS
+URL="http://imagr.fake.com/test_workflows.plist" # substitute your URL
+INDEX="5007" # substitute your index
+NBI="startosinstall_testing_Imagr" # substitute your nbi name
+```
+
+`make nbi` to build a (NetInstall-style) nbi containing Imagr. Transfer the resulting nbi to your NetBoot server and perform the needed incantations to get your NetBoot server to offer this nbi.
+
+Since we set `STARTTERMINAL=True` in the Makefile override, when this nbi boots it will open a terminal window instead of starting Imagr. This lets us see logging and debugging info. Launch Imagr like so:
+
+```
+/System/Installation/Packages/Imagr.app/Contents/MacOS/Imagr
+```

--- a/startosinstall_notes.md
+++ b/startosinstall_notes.md
@@ -1,4 +1,4 @@
-These are notes on the support for installing macOS using the `startosinstall` tool in "Install macOS Sierra.app" and "Install macOS High Sierra.app".
+These are notes on the support for installing macOS using the `startosinstall` tool in "Install macOS High Sierra.app". All testing and development is being done with the goal of using this component to install 10.13 and later. Early testing of using it to install 10.12.6 High Sierra was unsuccessful.
 
 #### Workflow component:
 
@@ -160,7 +160,7 @@ After the macOS install is complete and the machine boots to the new OS, it sits
 
 #### Testing notes
 
-Clone this repo locally:  
+You may use a machine running either 10.12.6 or 10.13 for testing. Clone this repo locally:  
 `git clone https://github.com/gregneagle/imagr.git gregneagle-imagr`
 
 In the same directory as the cloned repo, make a `config.mk` file. Recommended contents:

--- a/startosinstall_notes.md
+++ b/startosinstall_notes.md
@@ -158,6 +158,9 @@ After the macOS install is complete and the machine boots to the new OS, it sits
 
 #### Testing notes
 
+Clone this repo locally:  
+`git clone https://github.com/gregneagle/imagr.git gregneagle-imagr`
+
 In the same directory as the cloned repo, make a `config.mk` file. Recommended contents:
 
 ```

--- a/startosinstall_notes.md
+++ b/startosinstall_notes.md
@@ -27,36 +27,65 @@ Optional `additional_startosinstall_options`:
 
 ```xml
         <dict>
-			<key>type</key>
-			<string>startosinstall</string>
-			<key>url</key>
-			<string>http://imagr.fake.com/installers/Install%20macOS%20High%20Sierra-10.13.dmg</string>
-			<key>additional_startosinstall_options</key>
-			<array>
-				<string>--converttoapfs</string>
-				<string>NO</string>
-			</array>
+            <key>type</key>
+            <string>startosinstall</string>
+            <key>url</key>
+      <string>http://imagr.fake.com/installers/Install%20macOS%20High%20Sierra-10.13.dmg</string>
+            <key>additional_startosinstall_options</key>
+            <array>
+                <string>--converttoapfs</string>
+                <string>NO</string>
+            </array>
         </dict>
 ```
 
 Optional `additional_package_urls`:
 
 ```xml
-	<dict>
-		<key>type</key>
-		<string>startosinstall</string>
-		<key>url</key>
-		<string>http://imagr.fake.com/installers/Install%20macOS%20High%20Sierra-10.13.dmg</string>
-            	<key>additional_package_urls</key>
-           	<array>
-                	<string>http://imagr.fake.com/pkgs/AdminAccount.pkg</string>
-                	<string>http://imagr.fake.com/pkgs/SuppressSetupAssistant.pkg</string>
-                	<string>http://imagr.fake.com/pkgs/munkitools.pkg</string>
-                	<string>http://imagr.fake.com/pkgs/munki_kickstart.pkg</string>
-            	</array>
-	</dict>
+        <dict>
+            <key>type</key>
+            <string>startosinstall</string>
+            <key>url</key>
+      <string>http://imagr.fake.com/installers/Install%20macOS%20High%20Sierra-10.13.dmg</string>
+            <key>additional_package_urls</key>
+            <array>
+                <string>http://imagr.fake.com/pkgs/AdminAccount.pkg</string>
+                <string>http://imagr.fake.com/pkgs/SuppressSetupAssistant.pkg</string>
+                <string>http://imagr.fake.com/pkgs/munkitools.pkg</string>
+                <string>http://imagr.fake.com/pkgs/munki_kickstart.pkg</string>
+            </array>
+        </dict>
 ```
+
+Additional packages must be flat distribution-style packages. I did not find they needed to be signed.
 
 As of 10.13 release, specifying more than one additional package appears to be broken; `startosinstall` doesn't seem to properly stage all the packages.
 
-Additional packages must be flat distribution-style packages. I did not find they needed to be signed.
+Paths for all given packages are added to macOS Install Data/InstallInfo.plist under the "Additional Installs" key, but not all are actually copied to the paths indicated. When the machine restarts after the macOS install is set up, the installer complains that "The path /System/Installation/Packages/OSInstall.mpkg appears to be missing or damaged." and tells you to restart and try again.
+
+If you then restart to a different volume (locally attached or a network boot) you can see the problem. I tried to install four additional packages. macOS Install Data/InstallInfo.plist lists all four:
+
+```xml
+    <key>Additional Installers</key>
+    <array>
+    <string>UnwrappedInstallers/78d4e18c246101ac030409a3b28cf1ba6006055e/DA_adminaccount.pkg</string>
+    <string>UnwrappedInstallers/56609c54df6cc13597ea94d2ffd30540d7027dc7/SuppressSetupAssistant.pkg</string>
+    <string>UnwrappedInstallers/a04a3ba6f46deddca73b98679d09d2e41a95b2fa/munkitools.pkg</string>
+    <string>UnwrappedInstallers/6a0b81670c8f340ee2c51c98aa0572f5a8aa055b/munki_kickstart.pkg</string>
+    </array>
+```
+
+but the actual UnwrappedInstallers directory only has two of the packages:
+
+```
+$ ls -al macOS\ Install\ Data/UnwrappedInstallers/
+total 0
+drwxr-xr-x   4 root  wheel  136 Oct 11 10:11 .
+drwxr-xr-x@ 16 root  wheel  544 Oct 11 10:13 ..
+drwxr-xr-x   3 root  wheel  102 Oct 11 10:12 56609c54df6cc13597ea94d2ffd30540d7027dc7
+drwxr-xr-x   3 root  wheel  102 Oct 11 10:12 6a0b81670c8f340ee2c51c98aa0572f5a8aa055b
+```
+
+I can manually copy the missing packages to the paths listed in InstallInfo.plist and then if I restart into the macOS Installer environment, install proceeds successfully and the extra packages are installed, although with some UI bugs.
+
+One other bug: The additional packages are installed after the machine boots into the new OS for the first time. The mechanism that does the install appears to ignore the restart flag if it's set on any of the packages. I included the munkitools.pkg in my additional packages. It was successfully installed, but since there was no reboot after its install, Munki bootstrapping didn't actually work or kick in until after I manually restarted the machine one more time.

--- a/startosinstall_notes.md
+++ b/startosinstall_notes.md
@@ -1,4 +1,6 @@
-Workflow component:
+These are notes on the support for installing macOS using the `startosinstall` tool in "Install macOS Sierra.app" and "Install macOS High Sierra.app".
+
+#### Workflow component:
 
 ```xml
     <key>workflows</key>
@@ -56,6 +58,8 @@ Optional `additional_package_urls`:
             </array>
         </dict>
 ```
+
+#### Additional package notes
 
 Additional packages must be flat distribution-style packages. I did not find they needed to be signed.
 

--- a/startosinstall_notes.md
+++ b/startosinstall_notes.md
@@ -25,6 +25,8 @@ These are notes on the support for installing macOS using the `startosinstall` t
 
 `url` must point to a disk image containing an Install macOS.app at the root.
 
+This must be the **last** component in a given workflow; `startosinstall` will force a restart when it finishes setting up the macOS install; no subsequent workflow components will be executed.
+
 Optional `additional_startosinstall_options`:
 
 ```xml

--- a/startosinstall_notes.md
+++ b/startosinstall_notes.md
@@ -1,0 +1,62 @@
+Workflow component:
+
+```xml
+	<key>workflows</key>
+	<array>
+		<dict>
+			<key>components</key>
+			<array>
+				<dict>
+					<key>type</key>
+					<string>startosinstall</string>
+					<key>url</key>
+					<string>http://imagr.fake.com/installers/Install%20macOS%20High%20Sierra-10.13.dmg</string>
+				</dict>
+			</array>
+			<key>description</key>
+			<string>Installs High Sierra.</string>
+			<key>name</key>
+			<string>Install High Sierra</string>
+		</dict>
+	</array>
+```
+
+`url` must point to a disk image containing an Install macOS.app at the root.
+
+Optional `additional_startosinstall_options`:
+
+```xml
+        <dict>
+			<key>type</key>
+			<string>startosinstall</string>
+			<key>url</key>
+			<string>http://imagr.fake.com/installers/Install%20macOS%20High%20Sierra-10.13.dmg</string>
+			<key>additional_startosinstall_options</key>
+			<array>
+				<string>--converttoapfs</string>
+				<string>NO</string>
+			</array>
+        </dict>
+```
+
+Optional `additional_package_urls`:
+
+```xml
+		<dict>
+			<key>type</key>
+			<string>startosinstall</string>
+			<key>url</key>
+			<string>http://imagr.fake.com/installers/Install%20macOS%20High%20Sierra-10.13.dmg</string>
+            <key>additional_package_urls</key>
+            <array>
+                <string>http://imagr.fake.com/pkgs/AdminAccount.pkg</string>
+                <string>http://imagr.fake.com/pkgs/SuppressSetupAssistant.pkg</string>
+                <string>http://imagr.fake.com/pkgs/munkitools.pkg</string>
+                <string>http://imagr.fake.com/pkgs/munki_kickstart.pkg</string>
+            </array>
+		</dict>
+```
+
+As of 10.13 release, specifying more than one additional package appears to be broken; `startosinstall` doesn't seem to properly stage all the packages.
+
+Additional packages must be flat distribution-style packages. I did not find they needed to be signed.

--- a/startosinstall_notes.md
+++ b/startosinstall_notes.md
@@ -42,19 +42,19 @@ Optional `additional_startosinstall_options`:
 Optional `additional_package_urls`:
 
 ```xml
-		<dict>
-			<key>type</key>
-			<string>startosinstall</string>
-			<key>url</key>
-			<string>http://imagr.fake.com/installers/Install%20macOS%20High%20Sierra-10.13.dmg</string>
-            <key>additional_package_urls</key>
-            <array>
-                <string>http://imagr.fake.com/pkgs/AdminAccount.pkg</string>
-                <string>http://imagr.fake.com/pkgs/SuppressSetupAssistant.pkg</string>
-                <string>http://imagr.fake.com/pkgs/munkitools.pkg</string>
-                <string>http://imagr.fake.com/pkgs/munki_kickstart.pkg</string>
-            </array>
-		</dict>
+	<dict>
+		<key>type</key>
+		<string>startosinstall</string>
+		<key>url</key>
+		<string>http://imagr.fake.com/installers/Install%20macOS%20High%20Sierra-10.13.dmg</string>
+            	<key>additional_package_urls</key>
+           	<array>
+                	<string>http://imagr.fake.com/pkgs/AdminAccount.pkg</string>
+                	<string>http://imagr.fake.com/pkgs/SuppressSetupAssistant.pkg</string>
+                	<string>http://imagr.fake.com/pkgs/munkitools.pkg</string>
+                	<string>http://imagr.fake.com/pkgs/munki_kickstart.pkg</string>
+            	</array>
+	</dict>
 ```
 
 As of 10.13 release, specifying more than one additional package appears to be broken; `startosinstall` doesn't seem to properly stage all the packages.

--- a/startosinstall_notes.md
+++ b/startosinstall_notes.md
@@ -74,7 +74,7 @@ If you then restart to a different volume (locally attached or a network boot) y
 ```xml
     <key>Additional Installers</key>
     <array>
-        <string>UnwrappedInstallers/78d4e18c246101ac030409a3b28cf1ba6006055e/DA_adminaccount.pkg</string>
+        <string>UnwrappedInstallers/78d4e18c246101ac030409a3b28cf1ba6006055e/Adminaccount.pkg</string>
         <string>UnwrappedInstallers/56609c54df6cc13597ea94d2ffd30540d7027dc7/SuppressSetupAssistant.pkg</string>
         <string>UnwrappedInstallers/a04a3ba6f46deddca73b98679d09d2e41a95b2fa/munkitools.pkg</string>
         <string>UnwrappedInstallers/6a0b81670c8f340ee2c51c98aa0572f5a8aa055b/munki_kickstart.pkg</string>

--- a/startosinstall_notes.md
+++ b/startosinstall_notes.md
@@ -1,4 +1,4 @@
-These are notes on the support for installing macOS using the `startosinstall` tool in "Install macOS High Sierra.app". All testing and development is being done with the goal of using this component to install 10.13 and later. Early testing of using it to install 10.12.6 High Sierra was unsuccessful.
+These are notes on the support for installing macOS using the `startosinstall` tool in "Install macOS High Sierra.app". All testing and development is being done with the goal of using this component to install 10.13 and later. Early testing of using it to install 10.12.6 Sierra was unsuccessful.
 
 #### Workflow component:
 

--- a/startosinstall_notes.md
+++ b/startosinstall_notes.md
@@ -181,5 +181,5 @@ Since we set `STARTTERMINAL=True` in the Makefile override, when this nbi boots 
 /System/Installation/Packages/Imagr.app/Contents/MacOS/Imagr
 ```
 
-To test later updates to the code, you don't have to go through the lengthy `make nbi` process again; you can just do `make update` as long as you left a copy of the nbi in its original location (again, Desktop by default).
+To test later updates to the code, you don't have to go through the lengthy `make nbi` process again; you can just do `make update` as long as you left a copy of the nbi in its original location (again, Desktop by default). You'd then copy the updated nbi to the NetBoot server and test again.
 

--- a/startosinstall_notes.md
+++ b/startosinstall_notes.md
@@ -173,10 +173,13 @@ INDEX="5007" # substitute your index
 NBI="startosinstall_testing_Imagr" # substitute your nbi name
 ```
 
-`make nbi` to build a (NetInstall-style) nbi containing Imagr. Transfer the resulting nbi to your NetBoot server and perform the needed incantations to get your NetBoot server to offer this nbi.
+`make nbi` to build a (NetInstall-style) nbi containing Imagr. Transfer the resulting nbi (which is by default created on your Desktop) to your NetBoot server and perform the needed incantations to get your NetBoot server to offer this nbi.
 
 Since we set `STARTTERMINAL=True` in the Makefile override, when this nbi boots it will open a terminal window instead of starting Imagr. This lets us see logging and debugging info. Launch Imagr like so:
 
 ```
 /System/Installation/Packages/Imagr.app/Contents/MacOS/Imagr
 ```
+
+To test later updates to the code, you don't have to go through the lengthy `make nbi` process again; you can just do `make update` as long as you left a copy of the nbi in its original location (again, Desktop by default).
+

--- a/startosinstall_notes.md
+++ b/startosinstall_notes.md
@@ -96,6 +96,8 @@ I can manually copy the missing packages to the paths listed in InstallInfo.plis
 
 One other bug: The additional packages are installed after the machine boots into the new OS for the first time. The mechanism that does the install appears to ignore the restart flag if it's set on any of the packages. I included the munkitools.pkg in my additional packages. It was successfully installed, but since there was no reboot after its install, Munki bootstrapping didn't actually work or kick in until after I manually restarted the machine one more time.
 
+Assuming Apple eventually fixes these bugs, this should be a really useful way to deploy. But until then...
+
 
 #### Alternate workflow with additional packages
 

--- a/startosinstall_notes.md
+++ b/startosinstall_notes.md
@@ -1,24 +1,24 @@
 Workflow component:
 
 ```xml
-	<key>workflows</key>
-	<array>
-		<dict>
-			<key>components</key>
-			<array>
-				<dict>
-					<key>type</key>
-					<string>startosinstall</string>
-					<key>url</key>
-					<string>http://imagr.fake.com/installers/Install%20macOS%20High%20Sierra-10.13.dmg</string>
-				</dict>
-			</array>
-			<key>description</key>
-			<string>Installs High Sierra.</string>
-			<key>name</key>
-			<string>Install High Sierra</string>
-		</dict>
-	</array>
+    <key>workflows</key>
+    <array>
+        <dict>
+            <key>components</key>
+            <array>
+                <dict>
+                    <key>type</key>
+                    <string>startosinstall</string>
+                    <key>url</key>
+                    <string>http://imagr.fake.com/installers/Install%20macOS%20High%20Sierra-10.13.dmg</string>
+                </dict>
+            </array>
+            <key>description</key>
+            <string>Installs High Sierra.</string>
+            <key>name</key>
+            <string>Install High Sierra</string>
+        </dict>
+    </array>
 ```
 
 `url` must point to a disk image containing an Install macOS.app at the root.
@@ -30,7 +30,7 @@ Optional `additional_startosinstall_options`:
             <key>type</key>
             <string>startosinstall</string>
             <key>url</key>
-      <string>http://imagr.fake.com/installers/Install%20macOS%20High%20Sierra-10.13.dmg</string>
+      	    <string>http://imagr.fake.com/installers/Install%20macOS%20High%20Sierra-10.13.dmg</string>
             <key>additional_startosinstall_options</key>
             <array>
                 <string>--converttoapfs</string>
@@ -46,7 +46,7 @@ Optional `additional_package_urls`:
             <key>type</key>
             <string>startosinstall</string>
             <key>url</key>
-      <string>http://imagr.fake.com/installers/Install%20macOS%20High%20Sierra-10.13.dmg</string>
+            <string>http://imagr.fake.com/installers/Install%20macOS%20High%20Sierra-10.13.dmg</string>
             <key>additional_package_urls</key>
             <array>
                 <string>http://imagr.fake.com/pkgs/AdminAccount.pkg</string>
@@ -68,10 +68,10 @@ If you then restart to a different volume (locally attached or a network boot) y
 ```xml
     <key>Additional Installers</key>
     <array>
-    <string>UnwrappedInstallers/78d4e18c246101ac030409a3b28cf1ba6006055e/DA_adminaccount.pkg</string>
-    <string>UnwrappedInstallers/56609c54df6cc13597ea94d2ffd30540d7027dc7/SuppressSetupAssistant.pkg</string>
-    <string>UnwrappedInstallers/a04a3ba6f46deddca73b98679d09d2e41a95b2fa/munkitools.pkg</string>
-    <string>UnwrappedInstallers/6a0b81670c8f340ee2c51c98aa0572f5a8aa055b/munki_kickstart.pkg</string>
+        <string>UnwrappedInstallers/78d4e18c246101ac030409a3b28cf1ba6006055e/DA_adminaccount.pkg</string>
+        <string>UnwrappedInstallers/56609c54df6cc13597ea94d2ffd30540d7027dc7/SuppressSetupAssistant.pkg</string>
+        <string>UnwrappedInstallers/a04a3ba6f46deddca73b98679d09d2e41a95b2fa/munkitools.pkg</string>
+        <string>UnwrappedInstallers/6a0b81670c8f340ee2c51c98aa0572f5a8aa055b/munki_kickstart.pkg</string>
     </array>
 ```
 


### PR DESCRIPTION
### What does this PR do?
Adds support for installing macOS High Sierra using `startosinstall` to Imagr


### New Behavior
Adds a new workflow component of type "startosinstall" that uses an "Install macOS High Sierra.app" contained in a disk image to install High Sierra on the target volume.