### PR TITLE
allow custom rc-imaging scripts and show all disks for 10.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ Imagr.xcodeproj/project.xcworkspace/xcuserdata/*
 config.mk
 rc.netboot
 *.pyc
+rc-imaging/custom
 
 Imagr/post_test.py

--- a/Makefile
+++ b/Makefile
@@ -115,10 +115,13 @@ endif
 pkg-dir:
 	mkdir -p Packages/Extras
 ifeq ($(STARTTERMINAL),True)
-	printf '%s\n%s' '#!/bin/bash' '/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal' > Packages/Extras/rc.imaging
+	cp ./rc-imaging/terminal Packages/Extras/rc.imaging
+	cp -r /Applications/Utilities/Console.app ./Packages
+else ifeq ($(STARTTERMINAL),Custom)
+	cp ./rc-imaging/custom Packages/Extras/rc.imaging
 	cp -r /Applications/Utilities/Console.app ./Packages
 else
-	printf '%s\n%s' '#!/bin/bash' '/System/Installation/Packages/Imagr.app/Contents/MacOS/Imagr' > Packages/Extras/rc.imaging
+	cp ./rc-imaging/imagr Packages/Extras/rc.imaging
 endif
 	cp ./com.grahamgilbert.Imagr.plist Packages/
 ifeq ($(BUILD),Release)

--- a/rc-imaging/imagr
+++ b/rc-imaging/imagr
@@ -1,0 +1,7 @@
+#!/bin/bash
+OS=`/usr/bin/sw_vers -productVersion`
+if [[ "$OS" == *10.13* ]]
+  then
+    defaults write /var/root/Library/Preferences/com.apple.DiskUtility.plist SidebarShowAllDevices -bool TRUE
+fi
+/System/Installation/Packages/Imagr.app/Contents/MacOS/Imagr

--- a/rc-imaging/terminal
+++ b/rc-imaging/terminal
@@ -1,0 +1,7 @@
+#!/bin/bash
+OS=`/usr/bin/sw_vers -productVersion`
+if [[ "$OS" == *10.13* ]]
+  then
+    defaults write /var/root/Library/Preferences/com.apple.DiskUtility.plist SidebarShowAllDevices -bool TRUE
+fi
+/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal


### PR DESCRIPTION
### What does this PR do?
This PR makes it where Disk Utility will show the disks vs the Volumes, allowing an Imagr user to easily format a disk from APFS to HFS and vice versa. The default UI of Disk Utility hides this feature.

This PR also allows an admin to setup a custom rc.imaging script to do any number of things.

Simply add `STARTTERMINAL=Custom` to your config.mk file and make a `custom` file, places in the rc-imaging folder.

### Previous Behavior
Previously the makefile used `printf` to generate the rc.imaging file and did not setup Disk Utility properly for 10.13

### New Behavior
The makefile now calls out to the `rc-imaging` folder for these scripts, allowing an admin to easily write a script to do any number of custom things.

The admin should add a file called `custom` in the rc-imaging folder. A gitignore has also been setup for this file.

Example script:

```bash
#!/bin/bash
OS=`/usr/bin/sw_vers -productVersion`
if [[ "$OS" == *10.13* ]]
  then
    defaults write /var/root/Library/Preferences/com.apple.DiskUtility.plist SidebarShowAllDevices -bool TRUE
fi
/bin/mkdir -p /Volumes/imagrtest
/sbin/mount -t smbfs //username:password@IPADDRESS/sharepath /Volumes/imagrtest
/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal
```