### PR TITLE
dont track any .mk files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ Packages/
 AutoNBI.py
 FoundationPlist*
 Imagr.xcodeproj/project.xcworkspace/xcuserdata/*
-config.mk
+*.mk
 rc.netboot
 *.pyc
 rc-imaging/custom


### PR DESCRIPTION
Updates the gitignore to not track any .mk files. This allows me to have a test and production .mk file without git getting in the way every time.