### PR TITLE
fix: Allow custom rc files with release dmg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ dmg: build
 	cp -R ./build/Release/Imagr.app /tmp/imagr-build
 	cp ./validateplist /tmp/imagr-build/Tools
 	cp ./get_locale /tmp/imagr-build/Tools
+	cp -R ./rc-imaging /tmp/imagr-build/Tools
 	chmod +x /tmp/imagr-build/Tools/validateplist
 	chmod +x /tmp/imagr-build/Tools/get_locale
 	hdiutil create -srcfolder /tmp/imagr-build -volname "Imagr" -fs HFS+ -format UDZO -o Imagr.dmg


### PR DESCRIPTION
### What does this PR do?
This will copy the custom rc files to the release dmg.

### What issues does this PR fix or reference?
This fixes an issue that was introduced with #192.

### Previous Behavior
`make nbi` would fail on release dmgs.

### New Behavior
`make nbi` will work on released dmgs.