### PR TITLE
Auto detect Volume Format for eraseVolume

### DIFF
--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1676,7 +1676,7 @@ class MainController(NSObject):
         Erases the target volume.
         'name' can be used to rename the volume on reformat.
         'format' can be used to specify a format type.
-            'format' type of 'auto_hfs_or_apfs' will check for HFS+ or APFS
+        'format' type of 'auto_hfs_or_apfs' will check for HFS+ or APFS
         If no options are provided, it will format the volume with name 'Macintosh HD' with JHFS+.
         """
         NSLog("Format is: %@", format)

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1676,8 +1676,22 @@ class MainController(NSObject):
         Erases the target volume.
         'name' can be used to rename the volume on reformat.
         'format' can be used to specify a format type.
+            'format' type of 'auto_hfs_or_apfs' will check for HFS+ or APFS
         If no options are provided, it will format the volume with name 'Macintosh HD' with JHFS+.
         """
+        NSLog("Format is: %@", format)
+        
+        if format == 'auto_hfs_or_apfs':
+            if self.targetVolume._attributes['FilesystemType'] == 'hfs':
+                format='Journaled HFS+'
+                NSLog("Detected HFS+ - erasing target")
+            elif self.targetVolume._attributes['FilesystemType'] == 'apfs':
+                format='APFS'
+                NSLog("Detected APFS - erasing target")
+            else:
+                NSLog("Volume not HFS+ or APFS, system returned: %@", self.targetVolume._attributes['FilesystemType'])
+                self.errorMessage = "Not HFS+ or APFS - specify volume format and reload workflows."
+        
         cmd = ['/usr/sbin/diskutil', 'eraseVolume', format, name, self.targetVolume.mountpoint ]
         NSLog("%@", cmd)
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
### What does this PR do?

Setting the eraseVolume format key to "auto_hfs_or_apfs" the eraseVolume component will detect the format (HFS or APFS) of the volume and erase it using the same format.

The default if no format is specified is still JHFS+

### What issues does this PR fix or reference?

Currently when moving to 10.13 in a lab environment with mixed machines (HD, SSD, Fusion) the volume format may be different and the would require different workflows to erase the volume correctly. 

This change coupled with startosinstall APFS conversion also allows the same workflow to install 10.13 on a 10.12 machine and upgrade it to APFS and 10.13 to be fresh installed on an already APFS volume.