### PR TITLE
Why does this import socket?

### DIFF
--- a/Imagr/Resources/first-boot
+++ b/Imagr/Resources/first-boot
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-import socket
 import logging
 import time
 import plistlib


### PR DESCRIPTION
Can we remove the socket import, it seems unnecessary? its been in there since the beginning but I don't see it referenced anywhere in the code. This PR doesn't need to be merged.

### What does this PR do?
removes `import socket`
### What issues does this PR fix or reference?
removes unnecessary socket import

### Previous Behavior
(Remove this section if not relevant)

### New Behavior
(Remove this section if not relevant)