### PR TITLE
Allow APFS to HFS downgrade in script item

### DIFF
--- a/Imagr/gmacpyutil/macdisk.py
+++ b/Imagr/gmacpyutil/macdisk.py
@@ -46,7 +46,7 @@ class Disk(object):
             "BusProtocol", "Ejectable", "MediaType", "RAIDSlice",
             "FilesystemName", "RAIDMaster", "WholeDisk", "FreeSpace",
             "TotalSize", "GlobalPermissionsEnabled", "SMARTStatus",
-            "Writable", "ParentWholeDisk", "MediaName"]
+            "Writable", "ParentWholeDisk", "MediaName", "IORegistryEntryName"]
 
     for key in keys:
       try:


### PR DESCRIPTION
### What does this PR do?

Allows a script to downgrade an APFS volume to a HFS+ volume by deleting the APFS Container. The script must use the volume name "Imagr_APFS_Deleted" for the HFS+ volume that replaces the APFS volume. This is because the dev name can't be determined from the original layout.

### What issues does this PR fix or reference?

Error generated when deleting an APFS container: the physical disk device disappears and Imagr fails to continue.

### Previous Behavior
Generates Error

### New Behavior
The workflow continues as expected