### PR TITLE
Resolve bug where is_apfs_target is undefined causing Imagr to crash

### DIFF
--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1459,6 +1459,7 @@ class MainController(NSObject):
             is_apfs_target = parent_disk._attributes['IORegistryEntryName'] == "AppleAPFSMedia"
             NSLog("Target is child of an APFS container: %@", is_apfs_target)
         else:
+            is_apfs_target = None
             NSLog("Not a child of APFS")
 
         is_efi_target = self.targetVolume._attributes['IORegistryEntryName'] == "EFI System Partition"

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1459,7 +1459,7 @@ class MainController(NSObject):
             is_apfs_target = parent_disk._attributes['IORegistryEntryName'] == "AppleAPFSMedia"
             NSLog("Target is child of an APFS container: %@", is_apfs_target)
         else:
-            is_apfs_target = None
+            is_apfs_target = False
             NSLog("Not a child of APFS")
 
         is_efi_target = self.targetVolume._attributes['IORegistryEntryName'] == "EFI System Partition"


### PR DESCRIPTION
### What does this PR do?

Resolves an issue where Imagr refers to an undefined variable when using a non-APFS target like a CoreStorage Volume

### What issues does this PR fix or reference?

Issue not yet raised but observed in local tests

### Previous Behavior

Imagr crashes due to undefined variable `is_apfs_target`

### New Behavior

`is_apfs_target` defaults to False therefore all HFS+ volume types skip this if condition.