### PR TITLE
Change first-boot dir to /Library/Imagr-first-boot

### DIFF
--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -778,12 +778,23 @@ class MainController(NSObject):
         self.performSelectorOnMainThread_withObject_waitUntilDone_(
             self.updateProgressWithInfo_, info, objc.NO)
 
+    def setupFirstBootDir(self):
+        library_dir = os.path.join(self.targetVolume.mountpoint, 'Library/')
+        if not os.path.exists(library_dir):
+            os.makedirs(library_dir, 0755)
+            os.chown(library_dir, 0, 0)
+
+        first_boot_items_dir = os.path.join(library_dir, 
+            'Imagr-first-boot/items/')
+        if not os.path.exists(first_boot_items_dir):
+            os.makedirs(first_boot_items_dir, 0755)
+
     def setupFirstBootTools(self):
         # copy bits for first boot script
         packages_dir = os.path.join(
             self.targetVolume.mountpoint, 'Library/Imagr-first-boot/')
         if not os.path.exists(packages_dir):
-            os.makedirs(packages_dir)
+            self.setupFirstBootDir()
         Utils.copyFirstBoot(self.targetVolume.mountpoint,
                             self.waitForNetwork, self.firstBootReboot)
 
@@ -1380,7 +1391,7 @@ class MainController(NSObject):
         error = None
         dest_dir = os.path.join(target, 'Library/Imagr-first-boot/items')
         if not os.path.exists(dest_dir):
-            os.makedirs(dest_dir)
+            self.setupFirstBootDir()
         if not os.path.basename(url).endswith('.pkg') and not os.path.basename(url).endswith('.dmg'):
             error = "%s doesn't end with either '.pkg' or '.dmg'" % url
             return False, error
@@ -1535,7 +1546,7 @@ class MainController(NSObject):
         """
         dest_dir = os.path.join(target, 'Library/Imagr-first-boot/items')
         if not os.path.exists(dest_dir):
-            os.makedirs(dest_dir)
+            self.setupFirstBootDir()
         dest_file = os.path.join(dest_dir, "%03d" % number)
         if progress_method:
             progress_method("Copying script to %s" % dest_file, 0, '')

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -781,7 +781,7 @@ class MainController(NSObject):
     def setupFirstBootTools(self):
         # copy bits for first boot script
         packages_dir = os.path.join(
-            self.targetVolume.mountpoint, 'usr/local/first-boot/')
+            self.targetVolume.mountpoint, 'Library/Imagr-first-boot/')
         if not os.path.exists(packages_dir):
             os.makedirs(packages_dir)
         Utils.copyFirstBoot(self.targetVolume.mountpoint,
@@ -1378,7 +1378,7 @@ class MainController(NSObject):
 
     def downloadPackage(self, url, target, number, progress_method=None, additional_headers=None):
         error = None
-        dest_dir = os.path.join(target, 'usr/local/first-boot/items')
+        dest_dir = os.path.join(target, 'Library/Imagr-first-boot/items')
         if not os.path.exists(dest_dir):
             os.makedirs(dest_dir)
         if not os.path.basename(url).endswith('.pkg') and not os.path.basename(url).endswith('.dmg'):
@@ -1533,7 +1533,7 @@ class MainController(NSObject):
         Copies a
          script to a specific volume
         """
-        dest_dir = os.path.join(target, 'usr/local/first-boot/items')
+        dest_dir = os.path.join(target, 'Library/Imagr-first-boot/items')
         if not os.path.exists(dest_dir):
             os.makedirs(dest_dir)
         dest_file = os.path.join(dest_dir, "%03d" % number)

--- a/Imagr/Resources/com.grahamgilbert.imagr-first-boot-pkg.plist
+++ b/Imagr/Resources/com.grahamgilbert.imagr-first-boot-pkg.plist
@@ -6,7 +6,7 @@
 	<string>com.grahamgilbert.imagr-first-boot-pkg</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>/usr/local/first-boot/first-boot</string>
+		<string>/Library/Imagr-first-boot/first-boot</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>

--- a/Imagr/Resources/first-boot
+++ b/Imagr/Resources/first-boot
@@ -6,7 +6,7 @@ import os
 import subprocess
 import shutil
 
-firstboot_dir = '/usr/local/first-boot'
+firstboot_dir = '/Library/Imagr-first-boot'
 config_plist = os.path.join(firstboot_dir, 'config.plist')
 items_dir = os.path.join(firstboot_dir, 'items')
 items_done = None

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -733,7 +733,8 @@ def copyFirstBoot(root, network=True, reboot=True):
     script_dir = os.path.dirname(os.path.realpath(__file__))
     launchDaemon_dir = os.path.join(root, 'Library', 'LaunchDaemons')
     if not os.path.exists(launchDaemon_dir):
-        os.makedirs(launchDaemon_dir)
+        os.makedirs(launchDaemon_dir, 0755)
+        os.chown(launchDaemon_dir, 0, 0)
 
     if not os.path.exists(os.path.join(launchDaemon_dir,
     'com.grahamgilbert.imagr-first-boot-pkg.plist')):
@@ -748,7 +749,8 @@ def copyFirstBoot(root, network=True, reboot=True):
 
     launchAgent_dir = os.path.join(root, 'Library', 'LaunchAgents')
     if not os.path.exists(launchAgent_dir):
-        os.makedirs(launchAgent_dir)
+        os.makedirs(launchAgent_dir, 0755)
+        os.chown(launchAgent_dir, 0, 0)
 
     if not os.path.exists(os.path.join(launchAgent_dir, 'se.gu.it.LoginLog.plist')):
         shutil.copy(os.path.join(script_dir, 'se.gu.it.LoginLog.plist'),
@@ -766,7 +768,8 @@ def copyFirstBoot(root, network=True, reboot=True):
 
     helperTools_dir = os.path.join(root, 'Library', 'PrivilegedHelperTools')
     if not os.path.exists(helperTools_dir):
-        os.makedirs(helperTools_dir)
+        os.makedirs(helperTools_dir, 01755)
+        os.chown(helperTools_dir, 0, 0)
 
     if not os.path.exists(os.path.join(helperTools_dir, 'LoginLog.app')):
         shutil.copytree(os.path.join(script_dir, 'LoginLog.app'),

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -723,7 +723,7 @@ def copyFirstBoot(root, network=True, reboot=True):
     config_plist['Network'] = network
     config_plist['RetryCount'] = retry_count
     config_plist['Reboot'] = reboot
-    firstboot_dir = 'usr/local/first-boot'
+    firstboot_dir = 'Library/Imagr-first-boot'
     if not os.path.exists(os.path.join(root, firstboot_dir)):
         os.makedirs(os.path.join(root, firstboot_dir))
     plistlib.writePlist(config_plist, os.path.join(root, firstboot_dir,

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -768,7 +768,7 @@ def copyFirstBoot(root, network=True, reboot=True):
 
     helperTools_dir = os.path.join(root, 'Library', 'PrivilegedHelperTools')
     if not os.path.exists(helperTools_dir):
-        os.makedirs(helperTools_dir, 01755)
+        os.makedirs(helperTools_dir, 0755)
         os.chown(helperTools_dir, 0, 0)
 
     if not os.path.exists(os.path.join(helperTools_dir, 'LoginLog.app')):


### PR DESCRIPTION
### What does this PR do?
This PR changes the first boot tools directory from /usr/local/first-boot to /Library/Imagr-first-boot on the target volume. All references to the first-boot directory have been updated, as well.

### What issues does this PR fix or reference?
This addresses startosinstall issues with installers for macOS 10.13.4 and newer. It appears that if certain directories or files exist on the target volume, the installer may halt with the message "macOS could not be installed on your computer The operation could't be completed. (com.apple.osinstall error -3.)" soon after Imagr reboots into the macOS installer. 

Changing the directory where the first boot tools get stored is the easiest "fix." I suspect the root cause may be related to modifying items that would fall under SIP as /usr would be assigned the com.apple.rootless extended attribute somewhere during the install process, but I haven't been able to verify if that's the case.

However, I've also seen the installer halt after installing [SuppressSetupAssistant.pkg](https://github.com/munki/munki-pkg/tree/master/SuppressSetupAssistant) to the target disk while still booted into the NetInstall environment. As far as I can tell based on the rules defined in /System/Library/Sandbox/rootless.conf on an already-installed 10.13.5 system, /private/var doesn't fall under SIP, but the symlink at /var does. But the installer may be following a different set of rules. Creating the folder at [/private/tmp/pkgcache](https://github.com/grahamgilbert/imagr/blob/e8d44721c20d4c89d193130842b2131baf6c84cf/Imagr/osinstall.py#L139) on the target volume doesn't appear to cause startosinstall to fail, interestingly.

I ended up moving SuppressSetupAssistant.pkg into the additional_package_urls section of the startosinstall component and startosinstall works as expected, as long as the first-boot folder is moved elsewhere.

### Previous Behavior
The macOS 10.13.4 and 10.13.5 installers would fail to install if any component was set to run on first-boot.

### New Behavior
macOS 10.13.4 and 10.13.5 now install with first-boot items present on the target volume.

I also tested asr restores of 10.11.6 and 10.12.6 images and observed no change in behavior with the new first-boot location.