### PR TITLE
Hotfix/magervalp plus azaleski fb

### DIFF
--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -778,12 +778,23 @@ class MainController(NSObject):
         self.performSelectorOnMainThread_withObject_waitUntilDone_(
             self.updateProgressWithInfo_, info, objc.NO)
 
+    def setupFirstBootDir(self):
+        library_dir = os.path.join(self.targetVolume.mountpoint, 'Library/')
+        if not os.path.exists(library_dir):
+            os.makedirs(library_dir, 0755)
+            os.chown(library_dir, 0, 0)
+
+        first_boot_items_dir = os.path.join(library_dir, 
+            'Imagr-first-boot/items/')
+        if not os.path.exists(first_boot_items_dir):
+            os.makedirs(first_boot_items_dir, 0755)
+
     def setupFirstBootTools(self):
         # copy bits for first boot script
         packages_dir = os.path.join(
             self.targetVolume.mountpoint, 'Library/Imagr-first-boot/')
         if not os.path.exists(packages_dir):
-            os.makedirs(packages_dir)
+            self.setupFirstBootDir()
         Utils.copyFirstBoot(self.targetVolume.mountpoint,
                             self.waitForNetwork, self.firstBootReboot)
 
@@ -1380,7 +1391,7 @@ class MainController(NSObject):
         error = None
         dest_dir = os.path.join(target, 'Library/Imagr-first-boot/items')
         if not os.path.exists(dest_dir):
-            os.makedirs(dest_dir)
+            self.setupFirstBootDir()
         if not os.path.basename(url).endswith('.pkg') and not os.path.basename(url).endswith('.dmg'):
             error = "%s doesn't end with either '.pkg' or '.dmg'" % url
             return False, error
@@ -1535,7 +1546,7 @@ class MainController(NSObject):
         """
         dest_dir = os.path.join(target, 'Library/Imagr-first-boot/items')
         if not os.path.exists(dest_dir):
-            os.makedirs(dest_dir)
+            self.setupFirstBootDir()
         dest_file = os.path.join(dest_dir, "%03d" % number)
         if progress_method:
             progress_method("Copying script to %s" % dest_file, 0, '')

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -784,7 +784,7 @@ class MainController(NSObject):
             os.makedirs(library_dir, 0755)
             os.chown(library_dir, 0, 0)
 
-        first_boot_items_dir = os.path.join(library_dir, 
+        first_boot_items_dir = os.path.join(library_dir,
             'Imagr-first-boot/items/')
         if not os.path.exists(first_boot_items_dir):
             os.makedirs(first_boot_items_dir, 0755)
@@ -792,7 +792,7 @@ class MainController(NSObject):
     def setupFirstBootTools(self):
         # copy bits for first boot script
         packages_dir = os.path.join(
-            self.targetVolume.mountpoint, 'Library/Imagr-first-boot/')
+            self.targetVolume.mountpoint, '.imagr/first-boot/')
         if not os.path.exists(packages_dir):
             self.setupFirstBootDir()
         Utils.copyFirstBoot(self.targetVolume.mountpoint,
@@ -1389,7 +1389,7 @@ class MainController(NSObject):
 
     def downloadPackage(self, url, target, number, progress_method=None, additional_headers=None):
         error = None
-        dest_dir = os.path.join(target, 'Library/Imagr-first-boot/items')
+        dest_dir = os.path.join(target, '.imagr/first-boot/items')
         if not os.path.exists(dest_dir):
             self.setupFirstBootDir()
         if not os.path.basename(url).endswith('.pkg') and not os.path.basename(url).endswith('.dmg'):
@@ -1544,7 +1544,7 @@ class MainController(NSObject):
         Copies a
          script to a specific volume
         """
-        dest_dir = os.path.join(target, 'Library/Imagr-first-boot/items')
+        dest_dir = os.path.join(target, '.imagr/first-boot/items')
         if not os.path.exists(dest_dir):
             self.setupFirstBootDir()
         dest_file = os.path.join(dest_dir, "%03d" % number)

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -781,7 +781,7 @@ class MainController(NSObject):
     def setupFirstBootTools(self):
         # copy bits for first boot script
         packages_dir = os.path.join(
-            self.targetVolume.mountpoint, 'usr/local/first-boot/')
+            self.targetVolume.mountpoint, 'Library/Imagr-first-boot/')
         if not os.path.exists(packages_dir):
             os.makedirs(packages_dir)
         Utils.copyFirstBoot(self.targetVolume.mountpoint,
@@ -1378,7 +1378,7 @@ class MainController(NSObject):
 
     def downloadPackage(self, url, target, number, progress_method=None, additional_headers=None):
         error = None
-        dest_dir = os.path.join(target, 'usr/local/first-boot/items')
+        dest_dir = os.path.join(target, 'Library/Imagr-first-boot/items')
         if not os.path.exists(dest_dir):
             os.makedirs(dest_dir)
         if not os.path.basename(url).endswith('.pkg') and not os.path.basename(url).endswith('.dmg'):
@@ -1533,7 +1533,7 @@ class MainController(NSObject):
         Copies a
          script to a specific volume
         """
-        dest_dir = os.path.join(target, 'usr/local/first-boot/items')
+        dest_dir = os.path.join(target, 'Library/Imagr-first-boot/items')
         if not os.path.exists(dest_dir):
             os.makedirs(dest_dir)
         dest_file = os.path.join(dest_dir, "%03d" % number)

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -779,13 +779,7 @@ class MainController(NSObject):
             self.updateProgressWithInfo_, info, objc.NO)
 
     def setupFirstBootDir(self):
-        library_dir = os.path.join(self.targetVolume.mountpoint, 'Library/')
-        if not os.path.exists(library_dir):
-            os.makedirs(library_dir, 0755)
-            os.chown(library_dir, 0, 0)
-
-        first_boot_items_dir = os.path.join(library_dir,
-            'Imagr-first-boot/items/')
+        first_boot_items_dir = os.path.join(self.targetVolume.mountpoint, '.imagr/first-boot/items/')
         if not os.path.exists(first_boot_items_dir):
             os.makedirs(first_boot_items_dir, 0755)
 

--- a/Imagr/Resources/com.grahamgilbert.imagr-first-boot-pkg.plist
+++ b/Imagr/Resources/com.grahamgilbert.imagr-first-boot-pkg.plist
@@ -6,7 +6,7 @@
 	<string>com.grahamgilbert.imagr-first-boot-pkg</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>/Library/Imagr-first-boot/first-boot</string>
+		<string>/.imagr/first-boot/first-boot</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>

--- a/Imagr/Resources/com.grahamgilbert.imagr-first-boot-pkg.plist
+++ b/Imagr/Resources/com.grahamgilbert.imagr-first-boot-pkg.plist
@@ -6,7 +6,7 @@
 	<string>com.grahamgilbert.imagr-first-boot-pkg</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>/usr/local/first-boot/first-boot</string>
+		<string>/Library/Imagr-first-boot/first-boot</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>

--- a/Imagr/Resources/first-boot
+++ b/Imagr/Resources/first-boot
@@ -6,7 +6,7 @@ import os
 import subprocess
 import shutil
 
-firstboot_dir = '/usr/local/first-boot'
+firstboot_dir = '/Library/Imagr-first-boot'
 config_plist = os.path.join(firstboot_dir, 'config.plist')
 items_dir = os.path.join(firstboot_dir, 'items')
 items_done = None

--- a/Imagr/Resources/first-boot
+++ b/Imagr/Resources/first-boot
@@ -6,7 +6,7 @@ import os
 import subprocess
 import shutil
 
-firstboot_dir = '/Library/Imagr-first-boot'
+firstboot_dir = '/.imagr/first-boot'
 config_plist = os.path.join(firstboot_dir, 'config.plist')
 items_dir = os.path.join(firstboot_dir, 'items')
 items_done = None

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -733,7 +733,8 @@ def copyFirstBoot(root, network=True, reboot=True):
     script_dir = os.path.dirname(os.path.realpath(__file__))
     launchDaemon_dir = os.path.join(root, 'Library', 'LaunchDaemons')
     if not os.path.exists(launchDaemon_dir):
-        os.makedirs(launchDaemon_dir)
+        os.makedirs(launchDaemon_dir, 0755)
+        os.chown(launchDaemon_dir, 0, 0)
 
     if not os.path.exists(os.path.join(launchDaemon_dir,
     'com.grahamgilbert.imagr-first-boot-pkg.plist')):
@@ -748,7 +749,8 @@ def copyFirstBoot(root, network=True, reboot=True):
 
     launchAgent_dir = os.path.join(root, 'Library', 'LaunchAgents')
     if not os.path.exists(launchAgent_dir):
-        os.makedirs(launchAgent_dir)
+        os.makedirs(launchAgent_dir, 0755)
+        os.chown(launchAgent_dir, 0, 0)
 
     if not os.path.exists(os.path.join(launchAgent_dir, 'se.gu.it.LoginLog.plist')):
         shutil.copy(os.path.join(script_dir, 'se.gu.it.LoginLog.plist'),
@@ -766,7 +768,8 @@ def copyFirstBoot(root, network=True, reboot=True):
 
     helperTools_dir = os.path.join(root, 'Library', 'PrivilegedHelperTools')
     if not os.path.exists(helperTools_dir):
-        os.makedirs(helperTools_dir)
+        os.makedirs(helperTools_dir, 01755)
+        os.chown(helperTools_dir, 0, 0)
 
     if not os.path.exists(os.path.join(helperTools_dir, 'LoginLog.app')):
         shutil.copytree(os.path.join(script_dir, 'LoginLog.app'),

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -723,7 +723,7 @@ def copyFirstBoot(root, network=True, reboot=True):
     config_plist['Network'] = network
     config_plist['RetryCount'] = retry_count
     config_plist['Reboot'] = reboot
-    firstboot_dir = 'usr/local/first-boot'
+    firstboot_dir = 'Library/Imagr-first-boot'
     if not os.path.exists(os.path.join(root, firstboot_dir)):
         os.makedirs(os.path.join(root, firstboot_dir))
     plistlib.writePlist(config_plist, os.path.join(root, firstboot_dir,

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -723,7 +723,7 @@ def copyFirstBoot(root, network=True, reboot=True):
     config_plist['Network'] = network
     config_plist['RetryCount'] = retry_count
     config_plist['Reboot'] = reboot
-    firstboot_dir = 'Library/Imagr-first-boot'
+    firstboot_dir = '.imagr/first-boot'
     if not os.path.exists(os.path.join(root, firstboot_dir)):
         os.makedirs(os.path.join(root, firstboot_dir))
     plistlib.writePlist(config_plist, os.path.join(root, firstboot_dir,

--- a/Imagr/Utils.py
+++ b/Imagr/Utils.py
@@ -768,7 +768,7 @@ def copyFirstBoot(root, network=True, reboot=True):
 
     helperTools_dir = os.path.join(root, 'Library', 'PrivilegedHelperTools')
     if not os.path.exists(helperTools_dir):
-        os.makedirs(helperTools_dir, 01755)
+        os.makedirs(helperTools_dir, 0755)
         os.chown(helperTools_dir, 0, 0)
 
     if not os.path.exists(os.path.join(helperTools_dir, 'LoginLog.app')):

--- a/Imagr/osinstall.py
+++ b/Imagr/osinstall.py
@@ -136,6 +136,14 @@ def download_and_cache_pkgs(
     on the target volume. Return a list of the stashed paths.
     Raise PkgCaching error if there is a problem'''
     pkgpaths = []
+    private_dir = os.path.join(target, 'private')
+    private_tmp_dir = os.path.join(private_dir, 'tmp')
+    if not os.path.exists(private_tmp_dir):
+        os.makedirs(private_tmp_dir)
+        os.chown(private_dir, 0, 0)
+        os.chmod(private_dir, 0755)
+        os.chown(private_tmp_dir, 0, 0)
+        os.chmod(private_tmp_dir, 01777)
     dest_dir = os.path.join(target, 'private/tmp/pkgcache')
     if not os.path.exists(dest_dir):
         os.makedirs(dest_dir)


### PR DESCRIPTION
### What does this PR do?

This PR resolves osinstall status -3 errors installing to a volume which has had first-boot items stage on it prior to startosinstall rebooting. Additionally, MagerValps tmp fix has been applied manually.

The first boot items are now staged at /.imagr

This supersedes PR #212 and #214 

### What issues does this PR fix or reference?

osstatus error -3
