### PR TITLE
Fix for #216

### DIFF
--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -988,6 +988,9 @@ class MainController(NSObject):
                     NSLog(u"Included Workflow: %@", str(included_workflow))
                     # run the workflow
                     for component in workflow['components']:
+                        if (component.get('type') == 'startosinstall' and
+                            self.first_boot_items):
+                            self.setupFirstBootTools()
                         self.runComponent(component)
                     return
             else:


### PR DESCRIPTION
### What does this PR do?
Copies the first-boot tools before a startosinstall component is run within an included_workflow.

### What issues does this PR fix or reference?
Fixes #216

### Previous Behavior
first-boot scripts weren't run after a startosinstall that was kicked off from within an included_workflow because the LaunchDaemons were missing.

### New Behavior
first-boot scripts run