### PR TITLE
Fix LD_RUNPATH_SEARCH_PATHS + incorrect copyScript path

### DIFF
--- a/Imagr.xcodeproj/project.pbxproj
+++ b/Imagr.xcodeproj/project.pbxproj
@@ -572,7 +572,7 @@
 					"$(PROJECT_DIR)/Imagr/Resources",
 				);
 				INFOPLIST_FILE = Imagr/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks/Python.framework";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SYSTEM_LIBRARY_DIR)/Frameworks/Python.framework/Versions/2.7/lib/python2.7/config",
@@ -596,7 +596,7 @@
 					"$(PROJECT_DIR)/Imagr/Resources",
 				);
 				INFOPLIST_FILE = Imagr/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks/Python.framework";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SYSTEM_LIBRARY_DIR)/Frameworks/Python.framework/Versions/2.7/lib/python2.7/config",

--- a/Imagr/MainController.py
+++ b/Imagr/MainController.py
@@ -1768,7 +1768,7 @@ class MainController(NSObject):
         Copies a
          script to a specific volume
         """
-        dest_dir = os.path.join(target, 'private/var.imagr/first-boot/items')
+        dest_dir = os.path.join(target, 'private/var/.imagr/first-boot/items')
         if not os.path.exists(dest_dir):
             self.setupFirstBootDir()
         dest_file = os.path.join(dest_dir, "%03d" % number)


### PR DESCRIPTION
### What does this PR do?
Change to LD_RUNPATH_SEARCH_PATHS :
Fixes python "dyld: Library not loaded" error when launching imagr in Catalina recovery mode.
Verified build in Xcode v11.0.

Fixed copyScript path:
Allows script actions like computer_name and localize to work correctly.
