### PR TITLE
Make os.listdir deterministic with sorted list

### DIFF
--- a/Imagr/osinstall.py
+++ b/Imagr/osinstall.py
@@ -175,7 +175,7 @@ def filter_and_expand_paths(paths_array, file_extension):
         url = url.encode('utf8')
         url_path = urlparse.urlparse(urllib2.unquote(url)).path
         if os.path.isdir(url_path):
-            for f in os.listdir(url_path):
+            for f in sorted(os.listdir(url_path)):
                 if os.path.basename(f).endswith(file_extension):
                     new_paths.append(os.path.join(url, f))
         else:


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?

We are seeing that our packages can be installed in different order even though we number the packages and  assume they should go in sequence.  I doubt MacDeploy Stick was done with this in mind but we have a use case currently which assumes they will be installed the order.

@twocanoes 

### Previous Behavior
If I had a bunch of image files started 001, 002, 003, the installation would happen in a non-deterministic order because of os.listdir(https://stackoverflow.com/questions/4813061/non-alphanumeric-list-order-from-os-listdir).

- additional_packages defines where to look for the bundle pkgs https://github.com/imagr/imagr/blob/master/Imagr/osinstall.py#L214)
- This calls os.listdir() to find all the packages - https://github.com/imagr/imagr/blob/master/Imagr/osinstall.py#L150
- Which calls filter_and_expand_paths (https://github.com/imagr/imagr/blob/master/Imagr/osinstall.py#L172) that calls os.listdir (https://github.com/imagr/imagr/blob/master/Imagr/osinstall.py#L178)
- It seems like we create an array of calls to install the packages here invoking Contents/Resources/startosinstall (https://github.com/imagr/imagr/blob/master/Imagr/osinstall.py#L268) but not clear to me that startosinstall knows how to install things.

### New Behavior
Packages will now be installed in alphabetical order.  This allows the sequence of installs to be deterministic 

